### PR TITLE
Cleanup phase 2: fix tuning leak and geocodebr ID reattachment (C4, C5)

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -360,7 +360,7 @@ train_model <- function(model_data, grid_n = 10, sample = NULL, dev_mode = FALSE
   # Note: tune_race_anova requires at least 4 folds (more than 3 burn-in resamples)
   n_folds <- ifelse(dev_mode, 4, 10)
   vfolds <- rsample::group_vfold_cv(
-    model_data,
+    training_set,
     group = cod_localidade_ibge,
     v = n_folds
   )

--- a/R/string_matching.R
+++ b/R/string_matching.R
@@ -491,16 +491,20 @@ match_geocodebr_muni <- function(locais_muni, muni_ids = NULL) {
   
   # Attempt geocoding with error handling
   geocoded_result <- tryCatch({
-    # Ensure all text is properly encoded
-    geocode_data <- dt_geocode[, .(estado, municipio, logradouro)]
-    
+    # Ensure all text is properly encoded. Carry local_id through as a
+    # passthrough column so geocodebr reattaches it to each result via its
+    # internal row id (see the row-count assertion below), rather than us
+    # reassigning it by position afterward.
+    geocode_data <- dt_geocode[, .(local_id, estado, municipio, logradouro)]
+
     # Force UTF-8 encoding on all character columns
     char_cols <- names(geocode_data)[sapply(geocode_data, is.character)]
     for (col in char_cols) {
       set(geocode_data, j = col, value = enc2utf8(geocode_data[[col]]))
     }
-    
-    # Only use estado, municipio, logradouro to avoid database errors
+
+    # Only use estado, municipio, logradouro as address fields; local_id is a
+    # non-address passthrough column returned unchanged in the result.
     geocodebr::geocode(
       geocode_data,
       campos_endereco = geocodebr::definir_campos(
@@ -518,6 +522,7 @@ match_geocodebr_muni <- function(locais_muni, muni_ids = NULL) {
                   unique(dt_geocode$municipio), ":", e$message))
     # Return empty result with correct structure
     data.table(
+      local_id = integer(),
       estado = character(),
       municipio = character(),
       logradouro = character(),
@@ -532,9 +537,17 @@ match_geocodebr_muni <- function(locais_muni, muni_ids = NULL) {
   
   # If we got results, format them
   if (nrow(geocoded_result) > 0) {
-    # Add local_id back
-    geocoded_result[, local_id := dt_geocode$local_id]
-    
+    # geocodebr returns one row per input row (ties resolved) with all input
+    # columns preserved, so local_id is already attached to the correct result.
+    # Assert the invariant so a coordinate can never be tied to the wrong
+    # polling station: local_id must survive the round-trip and the row count
+    # must be unchanged.
+    stopifnot(
+      "local_id" %in% names(geocoded_result),
+      nrow(geocoded_result) == nrow(dt_geocode),
+      !anyNA(geocoded_result$local_id)
+    )
+
     # Create output in format consistent with other matching functions
     output <- data.table(
       local_id = geocoded_result$local_id,


### PR DESCRIPTION
## Purpose (plain language)

This fixes two verified bugs from the code-cleanup audit: a model that peeked at its own test set while tuning, and geocoded coordinates that could be attached to the wrong polling stations. Closes #33 (cleanup phase 2).

## What changed

**C4 — tuning leaked the test set** (`R/model.R`). The pipeline splits data into a training set and a held-out test set, but the cross-validation folds used during hyperparameter tuning were drawn from the *full* dataset, so test observations leaked into tuning. `group_vfold_cv()` now resamples `training_set` instead of `model_data`. Per the spec, published accuracy numbers are known-optimistic until the 2024 release's full run re-estimates them (phase 5 rider) — no dedicated retraining run here.

**C5 (partial) — geocodebr coordinates could attach to the wrong station** (`R/string_matching.R`). `match_geocodebr_muni()` reattached `local_id` by row position after geocoding (`geocoded_result[, local_id := dt_geocode$local_id]`), which is only correct if `geocodebr::geocode()` returns rows in the same order and count as the input. Instead, `local_id` is now carried through as a passthrough column in the geocode input; geocodebr merges it back to each result via its own internal row id, so the association is correct by identity regardless of reordering. Added a fail-loud invariant check that `local_id` survived the round-trip (present, no NAs) and that the row count is unchanged.

## Why the carry-through approach is safe

Reading the `geocodebr` 0.6.3 source (`geocode_core`): it stamps the input with an internal `tempidgeocodebr` row id, geocodes, then merges results back to the **full input** selecting all original column names (`select_columns = x_columns`). So every input column — including `local_id` — is preserved and correctly associated. `local_id` is an integer (`.I`) with a clean column name, so it passes geocodebr's column-name check untouched by the UTF-8 encoding loop.

## Scope note

The spec assigns the surrounding `tryCatch` restructuring (swallow-and-NULL error handling) to phase 3. This PR leaves both `tryCatch` blocks intact and only makes the reattachment correct. The one inner-handler edit — adding `local_id = integer()` to the empty-result `data.table` — is a required consequence of the passthrough (empty and non-empty result shapes must agree), not a restructuring.

## Testing

Verified end-to-end against a real municipality (Rio Branco, AC) using the locally cached geocodebr CNEFE data, with deliberately shuffled `local_id` values to prove reattachment by identity rather than position. Each address came back bound to its correct id and coordinates; the tightened assertion passes. Reviewed via `/simplify`, an independent Codex review, and a two-axis `/code-review` (Standards + Spec) — both axes passed; their shared suggestion (also guard column presence, not just row count) was applied before finalizing.

The full model retraining and pipeline run were **not** executed here (hours-long); the C4 change is a self-evident swap and the C5 change was verified with the focused test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)