### PR TITLE
Cleanup phase 4: dead code, shims, duplicated constants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,10 @@ Other source files: `R/config.R` (pipeline config + crew controllers), `R/utilit
 **External downloads required**:
 - CNEFE Census data (2010, 2017, 2022)
 - TSE geocoded data (ground truth)
-- Census tract shapefiles (via geobr)
+
+Census tract and municipality boundaries are read from pre-saved `.rds` files in
+`data/` (`census_tracts2010_shp.rds`, `muni_shp.rds`), not fetched at pipeline
+run time.
 
 **Outputs**:
 - `output/geocoded_polling_stations.csv.gz`: Final geocoded coordinates
@@ -141,12 +144,14 @@ For setting up this project on a new computer with AWS S3 integration, see [AWS_
 - **Data**: `data.table` for all operations
 - **Pipeline**: `targets` (+ `tarchetypes`)
 - **Modeling**: `tidymodels` stack (`parsnip`, `recipes`, `workflows`, `tune`, `finetune`, `rsample`, `yardstick`) with `bonsai` for lightgbm
-- **Record linkage**: `reclin2`; **spatial**: `sf`, `geosphere`, `geobr`; **string distance**: `stringdist`, `stringr`
+- **Record linkage**: `reclin2`; **spatial**: `sf`, `geosphere` (boundaries are pre-saved `.rds`, not fetched via `geobr`); **string distance**: `stringdist`, `stringr`
 - **Validation**: `validate` package (see `R/validation.R`)
 - **Parallelization**: `crew` (mirai-backed local controllers)
 - **Dependencies**: pinned with `renv` (`renv.lock`); `.Rprofile` prefers binary installs / `pak`
 
-Note: there is no active `testthat` suite — the `test_*.R` files under `backup/` are historical scratch scripts, not a maintained test directory.
+Note: the maintained test suite lives in `tests/` (see the Testing section above and
+[docs/specs/2026-07-testing-spec.md](docs/specs/2026-07-testing-spec.md)) — fast
+`testthat` unit tests plus a dev-mode integration check.
 
 ### Code Standards
 - Use snake_case naming

--- a/R/config.R
+++ b/R/config.R
@@ -12,6 +12,15 @@ library(crew)
 # ===== PIPELINE CONFIGURATION =====
 # Core configuration settings that control pipeline behavior
 
+# The 27 Brazilian federative units (26 states + the Federal District), used to
+# enumerate all states in production. Defined once and reused (cleanup phase 4
+# dedup).
+BRAZIL_STATES <- c(
+  "AC", "AL", "AM", "AP", "BA", "CE", "DF", "ES", "GO", "MA",
+  "MG", "MS", "MT", "PA", "PB", "PE", "PI", "PR", "RJ", "RN",
+  "RO", "RR", "RS", "SC", "SE", "SP", "TO"
+)
+
 get_pipeline_config <- function(dev_mode = FALSE) {
   # Get pipeline configuration based on development mode
   
@@ -44,9 +53,7 @@ get_pipeline_config <- function(dev_mode = FALSE) {
   # Add computed values
   config$n_cores <- config$max_workers
   config$states <- if (is.null(config$dev_states)) {
-    c("AC", "AL", "AM", "AP", "BA", "CE", "DF", "ES", "GO", "MA",
-      "MG", "MS", "MT", "PA", "PB", "PE", "PI", "PR", "RJ", "RN",
-      "RO", "RR", "RS", "SC", "SE", "SP", "TO")
+    BRAZIL_STATES
   } else {
     config$dev_states
   }
@@ -75,10 +82,7 @@ get_states_for_processing <- function(context, pipeline_config, custom_states = 
     },
     panel = {
       # Use custom states or default to all Brazilian states
-      custom_states %||% c("AC", "AL", "AM", "AP", "BA", "CE", "DF", "ES", 
-                          "GO", "MA", "MG", "MS", "MT", "PA", "PB", "PE", 
-                          "PI", "PR", "RJ", "RN", "RO", "RR", "RS", "SC", 
-                          "SE", "SP", "TO")
+      custom_states %||% BRAZIL_STATES
     },
     stop("Unknown context: ", context)
   )
@@ -162,27 +166,6 @@ get_expected_municipality_count_for_config <- function(pipeline_config) {
   } else {
     5570
   }
-}
-
-get_expected_municipality_range <- function(state_abbrev, tolerance = 0.05) {
-  # Get expected range of municipalities allowing for some tolerance
-  # Useful for validation as municipality counts can change slightly
-  
-  expected <- get_expected_municipality_count(state_abbrev)
-  
-  if (is.na(expected)) {
-    return(list(min = NA, max = NA, expected = NA))
-  }
-  
-  # Calculate range with tolerance
-  min_count <- floor(expected * (1 - tolerance))
-  max_count <- ceiling(expected * (1 + tolerance))
-  
-  return(list(
-    min = min_count,
-    max = max_count,
-    expected = expected
-  ))
 }
 
 # ===== CREW CONTROLLER CONFIGURATION =====

--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -67,6 +67,41 @@ standardize_column_names <- function(dt, inplace = FALSE) {
 
 # ===== DATA CLEANING FUNCTIONS =====
 
+# Human-readable labels for CNEFE "espécie de endereço" codes, used by
+# clean_cnefe10() and clean_cnefe22(). The two censuses code establishment types
+# differently: 2010 uses 7 codes (keyed on `especie`); 2022 uses 8 codes (keyed
+# on `cod_especie`), widening code 7's label to include reforms and adding a
+# distinct "estabelecimento religioso" (code 8). Defined once here (cleanup phase
+# 4 dedup) with the former "estabeleciemento" typo corrected to "estabelecimento"
+# — an output-visible label change noted for the 2024 release.
+cnefe_especie_labels <- function(year) {
+  common <- c(
+    "domicílio particular",
+    "domicílio coletivo",
+    "estabelecimento agropecuário",
+    "estabelecimento de ensino",
+    "estabelecimento de saúde",
+    "estabelecimento de outras finalidades"
+  )
+  if (year == 2010) {
+    data.table(
+      especie = 1:7,
+      especie_lab = c(common, "edificação em construção")
+    )
+  } else if (year == 2022) {
+    data.table(
+      cod_especie = 1:8,
+      especie_lab = c(
+        common,
+        "edificação em construção ou reforma",
+        "estabelecimento religioso"
+      )
+    )
+  } else {
+    stop(sprintf("cnefe_especie_labels(): unsupported CNEFE year %s.", year))
+  }
+}
+
 clean_cnefe22 <- function(cnefe22_file, muni_ids) {
   # Accept either file path or data.table
   if (is.character(cnefe22_file)) {
@@ -162,19 +197,7 @@ clean_cnefe22 <- function(cnefe22_file, muni_ids) {
     all.x = TRUE
   )
   # Add human-readable labels for CNEFE establishment types (especie codes)
-  especie_labs <- data.table(
-    cod_especie = 1:8,
-    especie_lab = c(
-      "domicílio particular",
-      "domicílio coletivo",
-      "estabeleciemento agropecuário",
-      "estabelecimento de ensino",
-      "estabelecimento de saúde",
-      "estabeleciemento de outras finalidades",
-      "edificação em construção ou reforma",
-      "estabeleciemento religioso"
-    )
-  )
+  especie_labs <- cnefe_especie_labels(2022)
 
   cnefe22 <- merge(
     cnefe22,
@@ -502,66 +525,67 @@ normalize_address <- function(x) {
   return(result)
 }
 
-normalize_school <- function(x) {
-  ## Common school-related terms to remove for better name matching
-  school_syns <- c(
-    "e m e i",
-    "esc inf",
-    "esc mun",
-    "unidade escolar",
-    "centro educacional",
-    "escola municipal",
-    "colegio estadual",
-    "cmei",
-    "emeif",
-    "emeief",
-    "grupo escolar",
-    "escola estadual",
-    "erem",
-    "colegio municipal",
-    "centro de ensino infantil",
-    "escola mul",
-    "e m",
-    "grupo municipal",
-    "e e",
-    "creche",
-    "escola",
-    "colegio",
-    "em",
-    "de referencia",
-    "centro comunitario",
-    "grupo",
-    "de referencia em ensino medio",
-    "intermediaria",
-    "ginasio municipal",
-    "ginasio",
-    "emef",
-    "centro de educacao infantil",
-    "esc",
-    "ee",
-    "e f",
-    "cei",
-    "emei",
-    "ensino fundamental",
-    "ensino medio",
-    "eeief",
-    "eef",
-    "e f",
-    "ens fun",
-    "eem",
-    "eeem",
-    "est ens med",
-    "est ens fund",
-    "ens fund",
-    "mul",
-    "professora",
-    "professor",
-    "eepg",
-    "eemg",
-    "prof",
-    "ensino fundamental"
-  )
+## Common school-related terms, stripped from school names for better matching in
+## normalize_school() and used as a school-detection feature by make_model_data()
+## in R/model.R. Defined once here and reused in both places (cleanup phase 4
+## dedup). Order is irrelevant — both uses build one regex alternation.
+school_synonyms <- c(
+  "e m e i",
+  "esc inf",
+  "esc mun",
+  "unidade escolar",
+  "centro educacional",
+  "escola municipal",
+  "colegio estadual",
+  "cmei",
+  "emeif",
+  "emeief",
+  "grupo escolar",
+  "escola estadual",
+  "erem",
+  "colegio municipal",
+  "centro de ensino infantil",
+  "escola mul",
+  "e m",
+  "grupo municipal",
+  "e e",
+  "creche",
+  "escola",
+  "colegio",
+  "em",
+  "de referencia",
+  "centro comunitario",
+  "grupo",
+  "de referencia em ensino medio",
+  "intermediaria",
+  "ginasio municipal",
+  "ginasio",
+  "emef",
+  "centro de educacao infantil",
+  "esc",
+  "ee",
+  "e f",
+  "cei",
+  "emei",
+  "ensino fundamental",
+  "ensino medio",
+  "eeief",
+  "eef",
+  "ens fun",
+  "eem",
+  "eeem",
+  "est ens med",
+  "est ens fund",
+  "ens fund",
+  "mul",
+  "professora",
+  "professor",
+  "eepg",
+  "eemg",
+  "prof"
+)
 
+normalize_school <- function(x) {
   ## Normalize school names by removing generic terms and standardizing format
   result <- stringi::stri_trans_general(x, "Latin-ASCII")
   result <- str_to_lower(result)
@@ -570,7 +594,7 @@ normalize_school <- function(x) {
   result <- str_squish(result)
   result <- str_remove_all(
     result,
-    paste0("\\b", school_syns, "\\b", collapse = "|")
+    paste0("\\b", school_synonyms, "\\b", collapse = "|")
   )
   result <- str_squish(result)
 
@@ -695,107 +719,6 @@ convert_coords_checked <- function(coord_strings, coord_name = "coordinate") {
 }
 
 
-read_cnefe_chunked <- function(file_path, chunk_size = 5e6, process_fn = NULL) {
-  # Read large CNEFE files in chunks to avoid memory exhaustion
-  # CNEFE 2022 files can exceed 40GB and contain >100M rows
-  # Processing in 5M row chunks keeps memory usage manageable
-  message(sprintf("Reading %s in chunks of %s rows", 
-                  basename(file_path), 
-                  format(chunk_size, big.mark = ",")))
-  
-  # First, get total number of rows
-  total_rows <- fread(file_path, select = 1L, sep = ";")[, .N]
-  n_chunks <- ceiling(total_rows / chunk_size)
-  
-  message(sprintf("Total rows: %s, will process in %d chunks", 
-                  format(total_rows, big.mark = ","), 
-                  n_chunks))
-  
-  # Process each chunk
-  results <- list()
-  
-  for (i in seq_len(n_chunks)) {
-    skip_rows <- (i - 1) * chunk_size
-    
-    message(sprintf("Processing chunk %d/%d (rows %s-%s)...", 
-                    i, n_chunks, 
-                    format(skip_rows + 1, big.mark = ","),
-                    format(min(skip_rows + chunk_size, total_rows), big.mark = ",")))
-    
-    # Read chunk
-    chunk <- fread(
-      file_path,
-      sep = ";",
-      nrows = chunk_size,
-      skip = skip_rows,
-      header = (i == 1),  # Only read header for first chunk
-      col.names = if (i > 1) names(results[[1]]) else NULL,
-      encoding = "UTF-8",
-      showProgress = FALSE
-    )
-    
-    # Apply processing function if provided
-    if (!is.null(process_fn)) {
-      chunk <- process_fn(chunk)
-    }
-    
-    results[[i]] <- chunk
-    
-    # Force garbage collection after each chunk
-    rm(chunk)
-    gc(verbose = FALSE)
-    
-    # Check memory usage
-    mem_usage <- gc()[2, 2]  # Current memory usage in MB
-    message(sprintf("  Memory usage: %.1f GB", mem_usage / 1024))
-    
-    # If memory usage is high, combine results so far and clear list
-    if (mem_usage > 50000) {  # If using more than 50GB
-      message("  High memory usage detected, combining chunks...")
-      if (length(results) > 1) {
-        combined <- rbindlist(results, use.names = TRUE, fill = TRUE)
-        results <- list(combined)
-        gc(verbose = FALSE)
-      }
-    }
-  }
-  
-  # Combine all results
-  message("Combining all chunks...")
-  final_result <- rbindlist(results, use.names = TRUE, fill = TRUE)
-  
-  message(sprintf("Finished reading %s rows", 
-                  format(nrow(final_result), big.mark = ",")))
-  
-  return(final_result)
-}
-
-
-monitor_memory <- function() {
-  gc_info <- gc()
-  
-  # Get system memory info on Linux
-  if (Sys.info()["sysname"] == "Linux") {
-    mem_info <- system("free -m", intern = TRUE)
-    total_mem <- as.numeric(gsub(".*Mem:\\s+(\\d+).*", "\\1", mem_info[2]))
-    used_mem <- as.numeric(gsub(".*Mem:\\s+\\d+\\s+(\\d+).*", "\\1", mem_info[2]))
-    free_mem <- total_mem - used_mem
-    
-    list(
-      r_memory_mb = sum(gc_info[, "used"]),
-      system_total_gb = total_mem / 1024,
-      system_used_gb = used_mem / 1024,
-      system_free_gb = free_mem / 1024,
-      system_used_pct = used_mem / total_mem * 100
-    )
-  } else {
-    list(
-      r_memory_mb = sum(gc_info[, "used"]),
-      system_info = "Not available on this platform"
-    )
-  }
-}
-
 clean_cnefe10 <- function(cnefe_file, muni_ids, tract_centroids, extract_schools = FALSE) {
   # Memory-efficient processing of CNEFE 2010 data
   
@@ -866,12 +789,8 @@ clean_cnefe10 <- function(cnefe_file, muni_ids, tract_centroids, extract_schools
   
   # Read and process CNEFE data
   if (is.character(cnefe_file)) {
-    if (file.size(cnefe_file) > 1e9) {  # Use chunks for files > 1GB
-      cnefe <- read_cnefe_chunked(cnefe_file, chunk_size = 5e6, process_fn = process_chunk)
-    } else {
-      cnefe <- fread(cnefe_file, sep = ";", encoding = "UTF-8")
-      cnefe <- process_chunk(cnefe)
-    }
+    cnefe <- fread(cnefe_file, sep = ";", encoding = "UTF-8")
+    cnefe <- process_chunk(cnefe)
   } else {
     cnefe <- process_chunk(copy(cnefe_file))
   }
@@ -886,15 +805,7 @@ clean_cnefe10 <- function(cnefe_file, muni_ids, tract_centroids, extract_schools
   
   # Merge especie labels
   message("Adding especie labels...")
-  especie_labs <- data.table(
-    especie = 1:7,
-    especie_lab = c(
-      "domicílio particular", "domicílio coletivo",
-      "estabeleciemento agropecuário", "estabelecimento de ensino",
-      "estabelecimento de saúde", "estabeleciemento de outras finalidades",
-      "edificação em construção"
-    )
-  )
+  especie_labs <- cnefe_especie_labels(2010)
   cnefe <- especie_labs[cnefe, on = "especie"]
   
   # Create final dataset with renamed columns

--- a/R/model.R
+++ b/R/model.R
@@ -22,7 +22,7 @@ make_model_data <- function(
   schools_cnefe22_match,
   agrocnefe_stbairro_match,
   inep_string_match,
-  geocodebr_match = NULL,  # New parameter with NULL default for backward compatibility
+  geocodebr_match,
   muni_demo,
   muni_area,
   locais,
@@ -154,66 +154,9 @@ make_model_data <- function(
     .(cod_localidade_ibge = Codmun7, logpop, pct_rural)
   ]
 
-  # Define synonyms for school names
-  # Most polling stations are located in schools, so detecting school-related
-  # terms helps the model prioritize school matches from CNEFE/INEP data
-  school_syns <- c(
-    "e m e i",
-    "esc inf",
-    "esc mun",
-    "unidade escolar",
-    "centro educacional",
-    "escola municipal",
-    "colegio estadual",
-    "cmei",
-    "emeif",
-    "emeief",
-    "grupo escolar",
-    "escola estadual",
-    "erem",
-    "colegio municipal",
-    "centro de ensino infantil",
-    "escola mul",
-    "e m",
-    "grupo municipal",
-    "e e",
-    "creche",
-    "escola",
-    "colegio",
-    "em",
-    "de referencia",
-    "centro comunitario",
-    "grupo",
-    "de referencia em ensino medio",
-    "intermediaria",
-    "ginasio municipal",
-    "ginasio",
-    "emef",
-    "centro de educacao infantil",
-    "esc",
-    "ee",
-    "e f",
-    "cei",
-    "emei",
-    "ensino fundamental",
-    "ensino medio",
-    "eeief",
-    "eef",
-    "e f",
-    "ens fun",
-    "eem",
-    "eeem",
-    "est ens med",
-    "est ens fund",
-    "ens fund",
-    "mul",
-    "professora",
-    "professor",
-    "eepg",
-    "eemg",
-    "prof",
-    "ensino fundamental"
-  )
+  # School-name synonyms (school_synonyms) are defined once in R/data_cleaning.R
+  # and reused here. Most polling stations are located in schools, so detecting
+  # school-related terms helps the model prioritize school matches.
 
   # Prepare address features
   addr_features <- locais[, .(
@@ -246,7 +189,7 @@ make_model_data <- function(
   ]
   addr_features[,
     school := fifelse(
-      grepl(paste0("\\b", school_syns, "\\b", collapse = "|"), norm_name) ==
+      grepl(paste0("\\b", school_synonyms, "\\b", collapse = "|"), norm_name) ==
         TRUE,
       1,
       0

--- a/R/panel_creation.R
+++ b/R/panel_creation.R
@@ -435,12 +435,7 @@ create_and_select_best_pairs_optimized <- function(data, years, blocking_column,
                                                   use_word_blocking = FALSE,
                                                   panel_weight_threshold = 0) {
   pairs_list <- list()
-  
-  # Load blocking functions if using word blocking
-  if (use_word_blocking && !exists("create_two_level_blocked_pairs")) {
-    source("R/panel_id_blocking_fns.R")
-  }
-  
+
   # Standardize column names in input data
   standardize_column_names(data, inplace = TRUE)
   

--- a/R/string_matching.R
+++ b/R/string_matching.R
@@ -41,31 +41,7 @@ prefilter_by_common_words <- function(query_strings, target_strings, min_common_
   return(matches)
 }
 
-chunk_string_match <- function(query_chunk, target_strings, method = "jw", 
-                              normalize_by_length = TRUE) {
-  # Perform string matching on a chunk of query strings
-  
-  # Calculate distance matrix for this chunk
-  dist_matrix <- stringdist::stringdistmatrix(
-    query_chunk,
-    target_strings,
-    method = method
-  )
-  
-  # Normalize by string length if requested
-  if (normalize_by_length) {
-    len_matrix <- outer(
-      nchar(query_chunk),
-      nchar(target_strings),
-      FUN = "pmax"
-    )
-    dist_matrix <- dist_matrix / len_matrix
-  }
-  
-  return(dist_matrix)
-}
-
-match_strings_memory_efficient <- function(query_strings, target_strings, 
+match_strings_memory_efficient <- function(query_strings, target_strings,
                                          method = "jw", chunk_size = 1000,
                                          normalize_by_length = TRUE,
                                          prefilter = TRUE,

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -107,45 +107,15 @@ filter_data_by_municipalities <- function(data, muni_codes, muni_col = "id_munic
   }
 }
 
-apply_dev_mode_filters <- function(data, config, filter_type = NULL, state_col = NULL, muni_col = NULL) {
-  # Apply development mode filters based on configuration
-  # Supports both old and new call signatures for backward compatibility
-  
-  # Handle old-style calls with named parameters
-  if (!is.null(filter_type)) {
-    if (filter_type == "state" && !is.null(state_col)) {
-      # Old-style state filtering
-      if (!is.null(config$dev_states)) {
-        return(filter_data_by_state(data, config$dev_states, state_col))
-      } else {
-        return(data)
-      }
-    } else if (filter_type == "municipality" && !is.null(muni_col)) {
-      # Municipality-based filtering for development mode
-      # Filter by municipalities from development states only
-      if (config$dev_mode && !is.null(config$dev_states)) {
-        # For municipality filtering in dev mode, we need to filter by state
-        # since we don't have a predefined list of municipalities
-        if ("estado_abrev" %in% names(data)) {
-          return(filter_data_by_state(data, config$dev_states, "estado_abrev"))
-        } else if ("sg_uf" %in% names(data)) {
-          return(filter_data_by_state(data, config$dev_states, "sg_uf"))
-        }
-      }
-      return(data)
-    }
-  }
-  
-  # Apply filtering based on configuration
-  if (!is.null(config$dev_states)) {
-    data <- filter_data_by_state(data, config$dev_states)
-  }
-  
-  if (!is.null(config$dev_municipalities)) {
-    data <- filter_data_by_municipalities(data, config$dev_municipalities)
-  }
-  
-  return(data)
+apply_dev_mode_filters <- function(data, config, state_col) {
+  # Single named seam for "what dev mode restricts data to", so the pipeline file
+  # reads intent and there is one place to re-expand if dev filtering ever regains
+  # a second dimension (it previously also filtered by municipality). In dev mode
+  # it keeps only the configured development states (config$dev_states) on the
+  # named state column; in production dev_states is NULL and the data passes
+  # through unchanged. The caller must name the state column (cleanup phase 4; H2
+  # convention).
+  filter_data_by_state(data, config$dev_states, state_col)
 }
 
 apply_brasilia_filters <- function(data, remove_brasilia = TRUE, state_col = "sg_uf") {
@@ -171,143 +141,6 @@ apply_brasilia_filters <- function(data, remove_brasilia = TRUE, state_col = "sg
 }
 
 # ===== PIPELINE HELPERS =====
-
-#' Process string match batch
-#'
-#' Generic function to process string matching in batches
-#' @param batch_ids Current batch ID being processed
-#' @param batch_assignments Municipality batch assignments table
-#' @param locais_data Filtered polling stations data
-#' @param match_data Data to match against (e.g., INEP, CNEFE)
-#' @param match_fn Matching function to use
-#' @param id_col Column name for municipality ID (default: "id_munic_7")
-#' @return Combined match results for the batch
-#' @export
-process_string_match_batch <- function(batch_ids, batch_assignments, locais_data,
-                                       match_data, match_fn, id_col = "id_munic_7") {
-  # Get municipalities for this batch
-  batch_info <- batch_assignments[batch_id == batch_ids]
-  batch_munis <- batch_info$muni_code
-
-  # Log batch start
-  message(sprintf(
-    "[%s] Processing string match batch %s: %d municipalities",
-    format(Sys.time(), "%H:%M:%S"),
-    batch_ids,
-    length(batch_munis)
-  ))
-
-  # Process all municipalities in this batch
-  batch_results <- lapply(seq_along(batch_munis), function(i) {
-    muni_code <- batch_munis[i]
-
-    # Log progress for large batches
-    if (length(batch_munis) > 5 && i %% 5 == 0) {
-      message(sprintf(
-        "  - Batch %s progress: %d/%d municipalities",
-        batch_ids,
-        i,
-        length(batch_munis)
-      ))
-    }
-    # Special handling for different matching functions
-    if (deparse(substitute(match_fn)) == "match_inep_muni") {
-      match_fn(
-        locais_muni = locais_data[cod_localidade_ibge == muni_code],
-        inep_muni = match_data[get(id_col) == muni_code]
-      )
-    } else if (deparse(substitute(match_fn)) == "match_schools_cnefe_muni") {
-      match_fn(
-        locais_muni = locais_data[cod_localidade_ibge == muni_code],
-        schools_cnefe_muni = match_data[get(id_col) == muni_code]
-      )
-    } else if (deparse(substitute(match_fn)) == "match_geocodebr_muni") {
-      match_fn(
-        locais_muni = locais_data[cod_localidade_ibge == muni_code],
-        muni_ids = match_data[get(id_col) == muni_code]
-      )
-    } else {
-      # Generic case - assumes standard interface
-      match_fn(
-        locais_muni = locais_data[cod_localidade_ibge == muni_code],
-        match_muni = match_data[get(id_col) == muni_code]
-      )
-    }
-  })
-
-  # Remove NULL results and combine
-  batch_results <- batch_results[!sapply(batch_results, is.null)]
-  if (length(batch_results) > 0) {
-    rbindlist(batch_results, use.names = TRUE, fill = TRUE)
-  } else {
-    data.table()
-  }
-}
-
-#' Process street/neighborhood match batch
-#'
-#' Specialized function for street and neighborhood matching
-#' @param batch_ids Current batch ID
-#' @param batch_assignments Municipality batch assignments
-#' @param locais_data Filtered polling stations
-#' @param st_data Street-level data
-#' @param bairro_data Neighborhood-level data
-#' @param match_fn Matching function (e.g., match_stbairro_cnefe_muni)
-#' @return Combined match results
-#' @export
-process_stbairro_match_batch <- function(batch_ids, batch_assignments, locais_data,
-                                         st_data, bairro_data, match_fn) {
-  # Get municipalities for this batch
-  batch_info <- batch_assignments[batch_id == batch_ids]
-  batch_munis <- batch_info$muni_code
-
-  # Log batch start with size info
-  total_size <- sum(batch_info$muni_size)
-  message(sprintf(
-    "[%s] Processing stbairro match batch %s: %d municipalities, %s total items",
-    format(Sys.time(), "%H:%M:%S"),
-    batch_ids,
-    length(batch_munis),
-    format(total_size, big.mark = ",")
-  ))
-
-  # Process all municipalities in this batch
-  batch_results <- lapply(seq_along(batch_munis), function(i) {
-    muni_code <- batch_munis[i]
-
-    # Log progress
-    if (i %% 2 == 0 || i == length(batch_munis)) {
-      message(sprintf(
-        "  - Batch %s: processing municipality %d/%d (code: %s)",
-        batch_ids,
-        i,
-        length(batch_munis),
-        muni_code
-      ))
-    }
-    if (deparse(substitute(match_fn)) == "match_stbairro_agrocnefe_muni") {
-      match_fn(
-        locais_muni = locais_data[cod_localidade_ibge == muni_code],
-        agrocnefe_st_muni = st_data[id_munic_7 == muni_code],
-        agrocnefe_bairro_muni = bairro_data[id_munic_7 == muni_code]
-      )
-    } else {
-      match_fn(
-        locais_muni = locais_data[cod_localidade_ibge == muni_code],
-        cnefe_st_muni = st_data[id_munic_7 == muni_code],
-        cnefe_bairro_muni = bairro_data[id_munic_7 == muni_code]
-      )
-    }
-  })
-
-  # Remove NULL results and combine
-  batch_results <- batch_results[!sapply(batch_results, is.null)]
-  if (length(batch_results) > 0) {
-    rbindlist(batch_results, use.names = TRUE, fill = TRUE)
-  } else {
-    data.table()
-  }
-}
 
 #' Process CNEFE by state
 #'

--- a/R/validation.R
+++ b/R/validation.R
@@ -48,20 +48,6 @@ validate_merge_stage <- function(merged_data, left_data, right_data = NULL,
     n_cols = ncol(merged_data)
   )
   
-  # If input data provided, calculate merge statistics
-  if (!is.null(left_data) && !is.null(right_data)) {
-    metadata$left_rows <- nrow(left_data)
-    metadata$right_rows <- nrow(right_data)
-    metadata$output_rows <- nrow(merged_data)
-    metadata$merge_type <- case_when(
-      nrow(merged_data) == nrow(left_data) ~ "left join",
-      nrow(merged_data) == nrow(right_data) ~ "right join",
-      nrow(merged_data) == max(nrow(left_data), nrow(right_data)) ~ "full join",
-      nrow(merged_data) < min(nrow(left_data), nrow(right_data)) ~ "inner join",
-      TRUE ~ "unknown"
-    )
-  }
-  
   # Return structured result
   structure(
     list(
@@ -107,13 +93,6 @@ validate_prediction_stage <- function(predictions, stage_name,
         deparse(prob_col), deparse(prob_col)
       ))[[1]]
     }
-  }
-  
-  # For backward compatibility, also check for coordinate predictions
-  if (any(c("pred_long", "pred_lat", "long", "lat") %in% names(predictions))) {
-    base_rules$has_coordinate_predictions <- quote(
-      any(c("pred_long", "pred_lat", "long", "lat") %in% names(.))
-    )
   }
   
   # Create validator
@@ -421,79 +400,6 @@ validate_inputs_consolidated <- function(muni_ids, inep_codes, locais_filtered, 
 }
 
 # ===== VALIDATION REPORT HELPERS =====
-
-ensure_quarto_path <- function() {
-  # Ensure QUARTO_PATH is set for crew workers
-  
-  if (Sys.getenv("QUARTO_PATH") == "") {
-    quarto_bin <- Sys.which("quarto")
-    if (nzchar(quarto_bin)) {
-      Sys.setenv(QUARTO_PATH = as.character(quarto_bin))
-      message("Setting QUARTO_PATH to: ", quarto_bin)
-      return(TRUE)
-    } else {
-      warning("Quarto not found in PATH")
-      return(FALSE)
-    }
-  }
-  return(TRUE)
-}
-
-render_sanity_check_report <- function(geocoded_data, output_file = NULL, 
-                                     output_format = "html_document") {
-  # Render sanity check report for geocoded data
-  
-  # Ensure quarto is available
-  ensure_quarto_path()
-  
-  if (is.null(output_file)) {
-    output_file <- paste0("sanity_check_", Sys.Date(), ".html")
-  }
-  
-  # Prepare data for report
-  report_data <- geocoded_data[, .(
-    ano,
-    estado = sg_uf,
-    municipio = nm_localidade,
-    n_locations = .N,
-    n_geocoded = sum(!is.na(final_long) & !is.na(final_lat)),
-    geocoding_rate = mean(!is.na(final_long) & !is.na(final_lat))
-  ), by = .(ano, sg_uf, nm_localidade)]
-  
-  # Create simple markdown report
-  report_content <- c(
-    "# Polling Station Geocoding Sanity Check",
-    paste("Generated:", Sys.Date()),
-    "",
-    "## Summary Statistics",
-    "",
-    knitr::kable(summary(report_data)),
-    "",
-    "## Geocoding Rates by State",
-    "",
-    knitr::kable(report_data[, .(
-      n_municipalities = .N,
-      total_locations = sum(n_locations),
-      total_geocoded = sum(n_geocoded),
-      avg_geocoding_rate = mean(geocoding_rate)
-    ), by = estado])
-  )
-  
-  # Write and render
-  temp_rmd <- tempfile(fileext = ".Rmd")
-  writeLines(report_content, temp_rmd)
-  
-  rmarkdown::render(
-    input = temp_rmd,
-    output_file = output_file,
-    output_format = output_format,
-    quiet = TRUE
-  )
-  
-  unlink(temp_rmd)
-  
-  return(output_file)
-}
 
 get_report_output_files <- function(base_name = "validation_report") {
   # Generate output file names for validation reports

--- a/_targets.R
+++ b/_targets.R
@@ -512,8 +512,7 @@ list(
     command = apply_dev_mode_filters(
       inep_data_all,
       pipeline_config,
-      filter_type = "municipality",
-      muni_col = "id_munic_7"
+      state_col = "uf"
     )
   ),
 
@@ -543,7 +542,6 @@ list(
     command = apply_dev_mode_filters(
       locais_all,
       pipeline_config,
-      filter_type = "state",
       state_col = "sg_uf"
     ),
     format = "qs"
@@ -678,7 +676,6 @@ list(
     command = apply_dev_mode_filters(
       secc_loc_map_all,
       pipeline_config,
-      filter_type = "state",
       state_col = "sg_uf"
     ),
     format = "qs"
@@ -1186,25 +1183,4 @@ list(
     path = "reports/polling_station_sanity_check.qmd",
     output_dir = "reports"
   )
-  #,
-  ## Methodology and Evaluation
-  # Only render in production mode
-  #tar_target(
-  #  name = geocode_writeup,
-  #  command = {
-  # Explicitly depend on pipeline_config
-  #    if (!pipeline_config$dev_mode) {
-  # Render the document in production mode
-  #     rmarkdown::render(
-  #      input = "./doc/geocoding_procedure.Rmd",
-  ##  )
-  # "./doc/geocoding_procedure.html"
-  # } else {
-  # Skip in dev mode - just return the expected output path
-  #  message("Skipping geocode_writeup in development mode")
-  #  "./doc/geocoding_procedure.html"
-  #}
-  #},
-  # format = "file"
-  #)
 )


### PR DESCRIPTION
## What this PR is for (plain language)

The pipeline had accumulated code that nothing runs anymore, a few functions that
kept two call styles alive only for the sake of old callers, and several constants
that were copy-pasted into two places. This PR removes the code that never
executes and collapses each duplicated constant to a single definition, so reading
the source tells you what the pipeline actually does. It is deliberately
low-risk: no intended change to production output except one spelling correction
in a human-readable label. Implements #35 (cleanup spec §Phase 4).

## Dead code removed (verified zero call sites)

- Functions: `chunk_string_match`, `get_expected_municipality_range`,
  `monitor_memory`, `process_string_match_batch`, `process_stbairro_match_batch`,
  `render_sanity_check_report` + its helper `ensure_quarto_path`, and
  `read_cnefe_chunked`.
  - `read_cnefe_chunked`'s only reference was an `is.character()` / `file.size()`
    branch in `clean_cnefe10`. Its sole caller (`process_cnefe_state`) always
    passes an already-read `data.table`, so that branch was unreachable; it is
    collapsed to the direct-read path.
- The dead `right_data` `case_when()` branch in `validate_merge_stage`
  (`right_data` is always `NULL` via its only caller, `validate_merge_simple`).
- The phantom `source("R/panel_id_blocking_fns.R")` and its always-false
  `exists()` guard (the guarded function is defined in the same file;
  `tar_source` already loads it).
- The ~20-line commented-out `geocode_writeup` target in `_targets.R`.

## Backward-compat shims removed (callers migrated first)

- `apply_dev_mode_filters()` collapsed from a dual old/new signature to a single
  explicit one, `apply_dev_mode_filters(data, config, state_col)`. The three
  `_targets.R` callers now name their state column. **Behavior note:** the old
  code auto-detected `estado_abrev`/`sg_uf` and, finding neither on the INEP
  table (its state column is `uf`), silently left INEP unfiltered in dev mode.
  INEP is now filtered on its real `uf` column in dev mode. **Production output
  is unchanged** — `dev_states` is `NULL` in production, so the filter passes data
  through untouched.
- `make_model_data()`'s `geocodebr_match = NULL` default dropped (the one caller
  already passes it explicitly).
- The backward-compat coordinate-predictions block in `validate_prediction_stage`.

## Duplicated constants collapsed to single definitions

- `school_synonyms` — was verbatim (with internal duplicates) in both
  `data_cleaning.R` and `model.R`; now one deduplicated top-level constant in
  `data_cleaning.R`, referenced from both. Identical behavior (both uses build one
  regex alternation, so duplicate/removed entries don't change matching).
- `BRAZIL_STATES` — was twice in `config.R`; now one top-level constant.
- CNEFE establishment ("espécie") labels — unified in a single
  `cnefe_especie_labels(year)` helper (fail-loud `stop()` on an unknown year),
  fixing the **"estabeleciemento" → "estabelecimento"** typo. This is an
  output-visible label change; **flagging for the 2024 release notes.** The 2010
  and 2022 censuses use different code sets, so the helper varies by year;
  downstream filters key on `"estabelecimento de ensino"`, which never carried the
  typo, so they are unaffected.

## Riders

- **CLAUDE.md:** corrected the stack description (`geobr` is not used; tract and
  municipality boundaries load from pre-saved `.rds` files) and a stale note that
  claimed tests lived under `backup/` (an active `testthat` suite now exists).
- **`backup/`:** deleted (5.3 GB of scratch). Note: it was gitignored and never
  committed, so this was an irreversible local deletion, not recoverable from git
  history as the spec assumed — done with explicit maintainer confirmation.
- **Lint count:** informational `lintr::lint_dir("R")` count (495) recorded in #35.

## Verification

- All 242 fast unit tests pass (`Rscript tests/testthat.R`); 1 unrelated skip.
- All `R/` sources and `_targets.R` parse.
- `/simplify` review (reuse/simplification/efficiency/altitude): clean; applied one
  comment improvement justifying `apply_dev_mode_filters` as a named seam.
- Codex review (`--base master`): no introduced bugs found.

## Deferred (noted, not done here)

`cnefe_especie_labels(year)` returns tables keyed on different column names per
year (`especie` for 2010, `cod_especie` for 2022), matching each cleaner's existing
merge. Standardizing that key name is a deeper reshape reaching into both cleaner
functions; left for later to keep this cleanup low-risk.

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwyeKHWWNa6z9MuYUZGsUm