### PR TITLE
Fix get_adaptive_chunk_size n_items cap (#52) and panel duplicate rows (#53)

### DIFF
--- a/R/panel_creation.R
+++ b/R/panel_creation.R
@@ -28,9 +28,23 @@ process_year_pairs <- function(panel, best_pairs, year_from, year_to) {
     return(panel)
   }
   
+  # Each transition must extend the panel into a year it does not yet hold. If
+  # the target column already exists, this transition is being processed twice:
+  # the join below would silently emit a duplicate i.local_id_<year_to> column
+  # that then inflates panel_id and the melt (the #53 duplicate-row bug). Fail
+  # loud rather than corrupt the panel.
+  year_to_col <- paste0("local_id_", year_to)
+  if (year_to_col %in% names(panel)) {
+    stop(
+      "process_year_pairs: panel already has column '", year_to_col,
+      "'; transition ", year_from, " -> ", year_to,
+      " is being processed more than once."
+    )
+  }
+
   # Standardize column names in best_pairs
   standardize_column_names(best_pairs, inplace = TRUE)
-  
+
   # Rename the columns in best_pairs to match the years
   clean_pairs <- best_pairs[, .(local_id_from = x_local_id, local_id_to = y_local_id)]
   setnames(
@@ -116,54 +130,38 @@ make_panel_ids <- function(panel_ids_df, panel_ids_states, geocoded_locais) {
 create_panel_dataset <- function(final_pairs_list, years) {
   # Ensure the years are sorted
   years <- sort(years)
-  
-  # Extract the best pairs for the first two years
-  first_year <- years[1]
-  second_year <- years[2]
-  best_pairs_first <- final_pairs_list[[paste0(first_year, "_", second_year)]]
-  
-  # Check if first pair is NULL or empty
-  if (is.null(best_pairs_first) || nrow(best_pairs_first) == 0) {
-    # Try to find the first non-empty pair
-    found_start <- FALSE
-    for (i in seq_along(years)[-length(years)]) {
-      year_from <- years[i]
-      year_to <- years[i + 1]
-      test_pairs <- final_pairs_list[[paste0(year_from, "_", year_to)]]
-      if (!is.null(test_pairs) && nrow(test_pairs) > 0) {
-        best_pairs_first <- test_pairs
-        first_year <- year_from
-        second_year <- year_to
-        found_start <- TRUE
-        break
-      }
+
+  # Walk the year-transitions once. Transition i links years[i] -> years[i + 1],
+  # for i in 1..(length(years) - 1). The first transition that has pairs seeds
+  # the panel; every later transition with pairs extends it by one year. Each
+  # transition is visited exactly once, so a two-year block never reprocesses
+  # its only pair (the source of the duplicate-row bug this replaced).
+  panel <- NULL
+  for (i in seq_len(length(years) - 1L)) {
+    best_pairs <- final_pairs_list[[paste0(years[i], "_", years[i + 1L])]]
+    if (is.null(best_pairs) || nrow(best_pairs) == 0) {
+      next
     }
-    
-    if (!found_start) {
-      # No valid pairs found at all
-      return(data.table())
+
+    if (is.null(panel)) {
+      # Seed the panel from the first non-empty transition.
+      standardize_column_names(best_pairs, inplace = TRUE)
+      panel <- best_pairs[, .(
+        local_id_first = x_local_id,
+        local_id_second = y_local_id
+      )]
+      setnames(
+        panel, c("local_id_first", "local_id_second"),
+        c(paste0("local_id_", years[i]), paste0("local_id_", years[i + 1L]))
+      )
+    } else {
+      panel <- process_year_pairs(panel, best_pairs, years[i], years[i + 1L])
     }
   }
-  
-  # Standardize column names
-  standardize_column_names(best_pairs_first, inplace = TRUE)
-  
-  # Create the initial panel dataset with standardized column names
-  panel <- best_pairs_first[, .(
-    local_id_first = x_local_id,
-    local_id_second = y_local_id
-  )]
-  setnames(
-    panel, c("local_id_first", "local_id_second"),
-    c(paste0("local_id_", first_year), paste0("local_id_", second_year))
-  )
-  
-  # Process each subsequent pair of years
-  for (i in seq(2, length(years) - 1)) {
-    year_from <- years[i]
-    year_to <- years[i + 1]
-    best_pairs <- final_pairs_list[[paste0(year_from, "_", year_to)]]
-    panel <- process_year_pairs(panel, best_pairs, year_from, year_to)
+
+  if (is.null(panel)) {
+    # No valid pairs found at all
+    return(data.table())
   }
   
   # Add panel_id

--- a/R/string_matching.R
+++ b/R/string_matching.R
@@ -157,10 +157,15 @@ get_adaptive_chunk_size <- function(n_items, available_memory_gb = 4) {
   
   # Chunk size is sqrt of max comparisons (for square distance matrix)
   chunk_size <- floor(sqrt(max_comparisons))
-  
+
   # Apply reasonable bounds
   chunk_size <- max(100, min(chunk_size, 10000))
-  
+
+  # Never chunk larger than the number of query items: chunking beyond n_items
+  # yields a single chunk of n_items anyway, so cap here for an honest chunk
+  # size. This cap wins over the lower bound when n_items < 100.
+  chunk_size <- min(chunk_size, n_items)
+
   return(chunk_size)
 }
 

--- a/tests/testthat/test-get_adaptive_chunk_size.R
+++ b/tests/testthat/test-get_adaptive_chunk_size.R
@@ -1,20 +1,26 @@
 ## Spec tests for get_adaptive_chunk_size() (R/string_matching.R).
 ## Chooses a chunk size = floor(sqrt(comparisons affordable in half the memory
-## budget)), clamped to [100, 10000]. Larger memory budgets yield larger chunks.
-##
-## NOTE: the `n_items` argument is currently ignored by the implementation (the
-## result depends only on available_memory_gb). That is a known smell tracked
-## separately; these tests pin only the documented memory-scaling contract and
-## the clamp bounds, not the n_items behavior.
+## budget)), clamped to [100, 10000], then capped at n_items (chunking larger
+## than the query set yields a single chunk of n_items anyway). Larger memory
+## budgets yield larger chunks, up to the n_items cap.
 
-test_that("get_adaptive_chunk_size clamps to the [100, 10000] range", {
-  expect_equal(get_adaptive_chunk_size(1000, available_memory_gb = 4), 10000)     # hits upper clamp
-  expect_equal(get_adaptive_chunk_size(1000, available_memory_gb = 1e-5), 100)    # hits lower clamp
+test_that("get_adaptive_chunk_size clamps the memory-based size to [100, 10000]", {
+  # n_items large enough not to bind, so the memory clamp is what shows through.
+  expect_equal(get_adaptive_chunk_size(1e6, available_memory_gb = 4), 10000)     # hits upper clamp
+  expect_equal(get_adaptive_chunk_size(1e6, available_memory_gb = 1e-5), 100)    # hits lower clamp
 })
 
 test_that("get_adaptive_chunk_size grows with the memory budget", {
-  small <- get_adaptive_chunk_size(1000, available_memory_gb = 0.01)
-  big <- get_adaptive_chunk_size(1000, available_memory_gb = 0.1)
+  small <- get_adaptive_chunk_size(1e6, available_memory_gb = 0.01)
+  big <- get_adaptive_chunk_size(1e6, available_memory_gb = 0.1)
   expect_lt(small, big)
   expect_true(small >= 100 && big <= 10000)
+})
+
+test_that("get_adaptive_chunk_size never exceeds n_items", {
+  # A generous memory budget would give 10000, but there is no point chunking
+  # more query rows than exist, so the result is capped at n_items.
+  expect_equal(get_adaptive_chunk_size(500, available_memory_gb = 4), 500)
+  # The cap wins even below the [100, ...] lower bound: 50 items -> one chunk of 50.
+  expect_equal(get_adaptive_chunk_size(50, available_memory_gb = 4), 50)
 })


### PR DESCRIPTION
## Purpose

Two small bug fixes surfaced while writing unit tests for the string-matching and panel-identity tranches. Both were reported as GitHub issues. In plain terms: one function was quietly ignoring an argument it was supposed to use, and another was producing double-counted rows in the panel that links polling stations across years. Neither changed any final coordinates, but the duplicate rows inflated downstream row counts.

Closes #52. Closes #53.

## #52 — `get_adaptive_chunk_size` ignored its `n_items` argument

The function is supposed to pick a work-chunk size based on both the number of query items and available memory, but it only ever used memory. Chunking more rows than exist is pointless, so the fix caps the memory-based chunk size at `n_items`. The spec test previously pinned only the memory-scaling behavior (with a note that `n_items` was ignored); it now pins the cap as well.

## #53 — `create_panel_dataset` emitted duplicate panel rows

A two-year block produced 6 rows instead of 4 — the later-year rows appeared twice. The cause was the loop `for (i in seq(2, length(years) - 1))`: when there are only two years, `seq(2, 1)` counts *down* to `c(2, 1)`, so the first year-transition was processed a second time. That reprocessing self-joined the panel and silently added a duplicate `local_id` column, which then flowed into both the panel-id computation and the reshape, doubling the rows.

The fix rewrites the panel seeding and extension as a single pass over the year-transitions that visits each transition exactly once and seeds from the first non-empty one. This also removes a latent instance of the same bug in the fallback path (when the very first transition has no pairs).

As a durable guardrail matching this repo's "fail loud and early" stance for data code, `process_year_pairs` now stops with an error if the panel already holds the target year's column, so any future double-processing fails immediately instead of silently corrupting the panel.

## Testing

- `Rscript tests/testthat.R` — all pass (244 pass, 1 skip, 0 fail), including the updated `get_adaptive_chunk_size` spec and the `make_panel_1block` spec (which now sees 4 distinct rows).
- Manual checks of `create_panel_dataset` on a 3-year chain, the first-transition-empty fallback, and the no-pairs case: correct panel ids, no duplicate rows, empty result respectively.
- `/simplify` pass (adopted the single-pass rewrite) and a clean Codex review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwyeKHWWNa6z9MuYUZGsUm