### PR TITLE
Fuse CNEFE aggregation into per-state cleaning (#67)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ _targets/
 _targets/meta
 _targets_dev/
 
+# Equivalence-harness baseline snapshot (tests/integration/equivalence_check.R)
+tests/integration/.equivalence_snapshot.rds
+
 # Added by Task Master AI
 # Logs
 logs

--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -849,8 +849,13 @@ clean_cnefe10 <- function(cnefe_file, muni_ids, tract_centroids, extract_schools
     schools <- addr[especie_lab == "estabelecimento de ensino"]
     
     if (nrow(schools) > 0) {
-      # Normalize school descriptions
+      # Normalize school descriptions, then drop rows with an empty normalized
+      # description. This harmonizes 2010 with get_cnefe22_schools(), which
+      # already filters norm_desc != "" (spec 2026-07-partition-reference-data,
+      # D7: a deliberate, accepted behavior change). An empty norm_desc carries
+      # no name to match against, so such rows never contribute a school match.
       schools[, norm_desc := normalize_school(desc)]
+      schools <- schools[norm_desc != ""]
       message(sprintf("Extracted %s schools", format(nrow(schools), big.mark = ",")))
     } else {
       message("No schools found in this dataset")

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -142,18 +142,22 @@ apply_brasilia_filters <- function(data, remove_brasilia = TRUE, state_col = "sg
 
 # ===== PIPELINE HELPERS =====
 
-#' Process CNEFE by state
+#' Process one state's CNEFE data into per-municipality aggregates
 #'
-#' Generic function to process CNEFE data state by state
+#' Reads and cleans one state's CNEFE file entirely in memory and returns only
+#' the small summaries the pipeline consumes: street- and neighborhood-level
+#' coordinate aggregates plus the school rows. The full cleaned address table is
+#' never returned (and therefore never persisted); it has no consumer other than
+#' these three aggregates (spec `2026-07-partition-reference-data-spec.md`, D5).
+#'
 #' @param state Current state being processed
 #' @param year CNEFE year (2010 or 2022)
 #' @param muni_ids Municipality identifiers
 #' @param tract_centroids Tract centroids (for 2010 only)
-#' @param extract_schools Whether to extract schools (2010 only)
-#' @return Cleaned CNEFE data for the state
+#' @return A list with `st` (street aggregates), `bairro` (neighborhood
+#'   aggregates), and `schools` (school rows) for this state
 #' @export
-process_cnefe_state <- function(state, year, muni_ids, tract_centroids = NULL,
-                                extract_schools = FALSE) {
+process_cnefe_state <- function(state, year, muni_ids, tract_centroids = NULL) {
   # Construct file path
   state_file <- file.path(
     "data",
@@ -183,29 +187,102 @@ process_cnefe_state <- function(state, year, muni_ids, tract_centroids = NULL,
       substr(setor_code, 1, 2) %in% state_codes
     ]
 
-    # Clean the data
-    result <- clean_cnefe10(
+    # Clean the data, extracting schools from the same in-memory pass (the
+    # duplicate 2010 schools read/clean pass is deleted per spec D5).
+    cleaned <- clean_cnefe10(
       cnefe_file = state_data,
       muni_ids = state_muni_ids,
       tract_centroids = state_tract_centroids,
-      extract_schools = extract_schools
+      extract_schools = TRUE
     )
-
-    # Return based on what was requested
-    if (extract_schools) {
-      return(result$schools)
-    } else {
-      return(result)
-    }
+    addr <- cleaned$data
+    schools <- cleaned$schools
   } else {
     # CNEFE 2022 processing
-    result <- clean_cnefe22(
+    addr <- clean_cnefe22(
       cnefe22_file = state_file,
       muni_ids = state_muni_ids
     )
-
-    return(result)
+    schools <- get_cnefe22_schools(addr)
   }
+
+  list(
+    st = aggregate_cnefe_coords(addr, "norm_street"),
+    bairro = aggregate_cnefe_coords(addr, "norm_bairro"),
+    schools = schools
+  )
+}
+
+#' Aggregate CNEFE coordinates to per-municipality group medians
+#'
+#' Collapses cleaned CNEFE rows to one row per `(id_munic_7, <group_col>)` group,
+#' taking the median coordinate and the group size, and keeps only groups seen
+#' more than once (`n > 1`). This is the aggregation formerly applied to the
+#' combined national `cnefe10`/`cnefe22` tables; because each municipality lives
+#' in exactly one state file, computing it per state and row-binding the results
+#' is equivalent to aggregating the national table.
+#'
+#' @param addr Cleaned CNEFE address data.table with `id_munic_7`,
+#'   `cnefe_long`, `cnefe_lat`, and the grouping column
+#' @param group_col Grouping column name (`"norm_street"` or `"norm_bairro"`)
+#' @return A data.table with columns `id_munic_7`, `<group_col>`, `long`, `lat`,
+#'   `n`
+#' @export
+aggregate_cnefe_coords <- function(addr, group_col) {
+  addr[
+    ,
+    .(
+      long = median(cnefe_long, na.rm = TRUE),
+      lat = median(cnefe_lat, na.rm = TRUE),
+      n = .N
+    ),
+    by = c("id_munic_7", group_col)
+  ][n > 1]
+}
+
+#' Combine one component of the per-state CNEFE results
+#'
+#' Row-binds a named component (`"st"`, `"bairro"`, or `"schools"`) across the
+#' per-state result lists returned by [process_cnefe_state()]. For the street and
+#' neighborhood aggregates, `unique_key` asserts the spec-D6 invariant: no
+#' `(id_munic_7, <key>)` may appear in more than one state slice. A duplicate is
+#' exactly what a municipality spanning two state files, or a mis-assigned state
+#' file, would produce, so it is a hard error rather than a silently merged row.
+#'
+#' @param state_results List of per-state result lists
+#' @param component Component name to extract from each per-state list
+#' @param unique_key Optional key columns whose uniqueness across slices is
+#'   asserted; `NULL` (the default) skips the check (used for `schools`, which is
+#'   legitimately many-per-municipality)
+#' @return The row-bound data.table for the requested component
+#' @export
+combine_cnefe_state_component <- function(state_results, component,
+                                          unique_key = NULL) {
+  combined <- rbindlist(
+    lapply(state_results, `[[`, component),
+    use.names = TRUE,
+    fill = TRUE
+  )
+
+  if (!is.null(unique_key)) {
+    dup_keys <- combined[, .N, by = unique_key][N > 1]
+    if (nrow(dup_keys) > 0) {
+      example <- paste(
+        unlist(dup_keys[1, ..unique_key]),
+        collapse = ", "
+      )
+      stop(sprintf(
+        paste0(
+          "combine_cnefe_state_component(): %d '%s' key(s) duplicated across ",
+          "state slices (e.g. %s). A municipality spanning two state files or ",
+          "a mis-assigned state file produces this."
+        ),
+        nrow(dup_keys), component, example
+      ))
+    }
+  }
+
+  combined
 }
 
 #' Process INEP string matching in batches

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -264,22 +264,23 @@ combine_cnefe_state_component <- function(state_results, component,
     fill = TRUE
   )
 
-  if (!is.null(unique_key)) {
+  # anyDuplicated() is a single pass with a 0L fast path, so the expensive
+  # per-key count table is only materialized on the rare error path (to build
+  # the diagnostic), not on every combine.
+  if (!is.null(unique_key) && anyDuplicated(combined, by = unique_key) > 0L) {
     dup_keys <- combined[, .N, by = unique_key][N > 1]
-    if (nrow(dup_keys) > 0) {
-      example <- paste(
-        unlist(dup_keys[1, ..unique_key]),
-        collapse = ", "
-      )
-      stop(sprintf(
-        paste0(
-          "combine_cnefe_state_component(): %d '%s' key(s) duplicated across ",
-          "state slices (e.g. %s). A municipality spanning two state files or ",
-          "a mis-assigned state file produces this."
-        ),
-        nrow(dup_keys), component, example
-      ))
-    }
+    example <- paste(
+      unlist(dup_keys[1, ..unique_key]),
+      collapse = ", "
+    )
+    stop(sprintf(
+      paste0(
+        "combine_cnefe_state_component(): %d '%s' key(s) duplicated across ",
+        "state slices (e.g. %s). A municipality spanning two state files or ",
+        "a mis-assigned state file produces this."
+      ),
+      nrow(dup_keys), component, example
+    ))
   }
 
   combined

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -216,17 +216,21 @@ process_cnefe_state <- function(state, year, muni_ids, tract_centroids = NULL) {
 #' Aggregate CNEFE coordinates to per-municipality group medians
 #'
 #' Collapses cleaned CNEFE rows to one row per `(id_munic_7, <group_col>)` group,
-#' taking the median coordinate and the group size, and keeps only groups seen
-#' more than once (`n > 1`). This is the aggregation formerly applied to the
-#' combined national `cnefe10`/`cnefe22` tables; because each municipality lives
-#' in exactly one state file, computing it per state and row-binding the results
-#' is equivalent to aggregating the national table.
+#' taking the median coordinate and the group size `n`. This is the aggregation
+#' formerly applied to the combined national `cnefe10`/`cnefe22` tables; because
+#' each municipality lives in exactly one state file, computing it per state and
+#' row-binding the results is equivalent to aggregating the national table.
+#'
+#' Singleton groups (`n == 1`) are intentionally NOT dropped here: the singleton
+#' drop happens in [combine_cnefe_state_component()], *after* the cross-slice
+#' duplicate check, so that a key accidentally split one-and-one across two state
+#' files is caught by the D6 invariant instead of being filtered away unseen.
 #'
 #' @param addr Cleaned CNEFE address data.table with `id_munic_7`,
 #'   `cnefe_long`, `cnefe_lat`, and the grouping column
 #' @param group_col Grouping column name (`"norm_street"` or `"norm_bairro"`)
 #' @return A data.table with columns `id_munic_7`, `<group_col>`, `long`, `lat`,
-#'   `n`
+#'   `n` (one row per group, including `n == 1` groups)
 #' @export
 aggregate_cnefe_coords <- function(addr, group_col) {
   addr[
@@ -237,7 +241,7 @@ aggregate_cnefe_coords <- function(addr, group_col) {
       n = .N
     ),
     by = c("id_munic_7", group_col)
-  ][n > 1]
+  ]
 }
 
 #' Combine one component of the per-state CNEFE results
@@ -249,12 +253,19 @@ aggregate_cnefe_coords <- function(addr, group_col) {
 #' exactly what a municipality spanning two state files, or a mis-assigned state
 #' file, would produce, so it is a hard error rather than a silently merged row.
 #'
+#' The duplicate check runs on the un-thinned aggregates (singleton `n == 1`
+#' groups still present), so a key split one-and-one across two state files is
+#' detected here; only afterwards are singleton groups dropped (`n > 1`), matching
+#' the national aggregation's `[n > 1]` filter. `schools` has no `n` column and is
+#' returned in full.
+#'
 #' @param state_results List of per-state result lists
 #' @param component Component name to extract from each per-state list
 #' @param unique_key Optional key columns whose uniqueness across slices is
 #'   asserted; `NULL` (the default) skips the check (used for `schools`, which is
 #'   legitimately many-per-municipality)
-#' @return The row-bound data.table for the requested component
+#' @return The row-bound data.table for the requested component (aggregate
+#'   components thinned to `n > 1` groups)
 #' @export
 combine_cnefe_state_component <- function(state_results, component,
                                           unique_key = NULL) {
@@ -281,6 +292,13 @@ combine_cnefe_state_component <- function(state_results, component,
       ),
       nrow(dup_keys), component, example
     ))
+  }
+
+  # Drop singleton groups only now, after the cross-slice duplicate check, so a
+  # 1+1 split cannot be filtered away before the invariant sees it. Aggregate
+  # components carry an `n` column; `schools` does not and passes through whole.
+  if ("n" %in% names(combined)) {
+    combined <- combined[n > 1]
   }
 
   combined

--- a/_targets.R
+++ b/_targets.R
@@ -284,19 +284,23 @@ list(
   # ========================================
 
   ## CNEFE 2010 Processing
+  #
+  # Per-state cleaning returns list(st, bairro, schools) computed in memory; the
+  # full cleaned address rows are never persisted (spec D5). The national
+  # `cnefe10` combine and the duplicate schools read/clean pass are deleted; the
+  # small aggregates are row-bound from the per-state results below.
   tar_target(
     name = cnefe10_states,
     command = get_states_for_processing("cnefe10", pipeline_config)
   ),
-  # Process CNEFE10 state by state to avoid memory issues
+  # Clean each state and aggregate in-memory (streets, neighborhoods, schools)
   tar_target(
-    name = cnefe10_cleaned_by_state,
+    name = cnefe10_by_state,
     command = process_cnefe_state(
       state = cnefe10_states,
       year = 2010,
       muni_ids = muni_ids,
-      tract_centroids = tract_centroids,
-      extract_schools = FALSE
+      tract_centroids = tract_centroids
     ),
     pattern = map(cnefe10_states),
     format = "qs",
@@ -304,44 +308,15 @@ list(
     resources = tar_resources(
       crew = tar_resources_crew(controller = "memory_limited")
     )
-  ),
-  # Extract schools by state for CNEFE10
-  tar_target(
-    name = schools_cnefe10_by_state,
-    command = process_cnefe_state(
-      state = cnefe10_states,
-      year = 2010,
-      muni_ids = muni_ids,
-      tract_centroids = tract_centroids,
-      extract_schools = TRUE
-    ),
-    pattern = map(cnefe10_states),
-    format = "qs",
-    iteration = "list",
-    resources = tar_resources(
-      crew = tar_resources_crew(controller = "memory_limited")
-    )
-  ),
-  # Combine all cleaned state data for CNEFE10
-  tar_target(
-    name = cnefe10,
-    command = rbindlist(
-      cnefe10_cleaned_by_state,
-      use.names = TRUE,
-      fill = TRUE
-    ),
-    format = "qs",
-    storage = "worker",
-    retrieval = "worker"
   ),
   # Get list of states to process based on mode
   tar_target(
     name = cnefe22_states,
     command = get_states_for_processing("cnefe22", pipeline_config)
   ),
-  # Process CNEFE22 state by state to avoid memory issues
+  # Clean each state and aggregate in-memory (streets, neighborhoods, schools)
   tar_target(
-    name = cnefe22_cleaned_by_state,
+    name = cnefe22_by_state,
     command = process_cnefe_state(
       state = cnefe22_states,
       year = 2022,
@@ -354,57 +329,33 @@ list(
       crew = tar_resources_crew(controller = "memory_limited")
     )
   ),
-  # Combine all cleaned state data
-  tar_target(
-    name = cnefe22,
-    command = rbindlist(
-      cnefe22_cleaned_by_state,
-      use.names = TRUE,
-      fill = TRUE
-    ),
-    format = "qs",
-    storage = "worker",
-    retrieval = "worker"
-  ),
 
-  ## Combine state-level school extracts for 2010 CNEFE
+  ## Combine per-state school extracts for 2010 CNEFE
   tar_target(
     name = schools_cnefe10,
-    command = rbindlist(
-      schools_cnefe10_by_state,
-      use.names = TRUE,
-      fill = TRUE
+    command = combine_cnefe_state_component(cnefe10_by_state, "schools"),
+    format = "qs",
+    storage = "worker",
+    retrieval = "worker"
+  ),
+  ## Create a dataset of streets in 2010 CNEFE (D6 invariant asserted at combine)
+  tar_target(
+    name = cnefe10_st,
+    command = combine_cnefe_state_component(
+      cnefe10_by_state, "st",
+      unique_key = c("id_munic_7", "norm_street")
     ),
     format = "qs",
     storage = "worker",
     retrieval = "worker"
   ),
-  ## Create a dataset of streets in 2010 CNEFE
-  tar_target(
-    name = cnefe10_st,
-    command = cnefe10[,
-      .(
-        long = median(cnefe_long, na.rm = TRUE),
-        lat = median(cnefe_lat, na.rm = TRUE),
-        n = .N
-      ),
-      by = .(id_munic_7, norm_street)
-    ][n > 1],
-    format = "qs",
-    storage = "worker",
-    retrieval = "worker"
-  ),
-  ## Create a dataset of neighborhoods in 2010 CNEFE
+  ## Create a dataset of neighborhoods in 2010 CNEFE (D6 invariant asserted)
   tar_target(
     name = cnefe10_bairro,
-    command = cnefe10[,
-      .(
-        long = median(cnefe_long, na.rm = TRUE),
-        lat = median(cnefe_lat, na.rm = TRUE),
-        n = .N
-      ),
-      by = .(id_munic_7, norm_bairro)
-    ][n > 1],
+    command = combine_cnefe_state_component(
+      cnefe10_by_state, "bairro",
+      unique_key = c("id_munic_7", "norm_bairro")
+    ),
     format = "qs",
     storage = "worker",
     retrieval = "worker"
@@ -454,40 +405,32 @@ list(
     storage = "worker",
     retrieval = "worker"
   ),
+  ## Combine per-state school extracts for 2022 CNEFE
   tar_target(
-    ## Extract schools frome 2022 CNEFE
     name = schools_cnefe22,
-    command = get_cnefe22_schools(cnefe22),
+    command = combine_cnefe_state_component(cnefe22_by_state, "schools"),
     format = "qs",
     storage = "worker",
     retrieval = "worker"
   ),
-  ## Create a dataset of streets in 2022 CNEFE
+  ## Create a dataset of streets in 2022 CNEFE (D6 invariant asserted at combine)
   tar_target(
     name = cnefe22_st,
-    command = cnefe22[,
-      .(
-        long = median(cnefe_long, na.rm = TRUE),
-        lat = median(cnefe_lat, na.rm = TRUE),
-        n = .N
-      ),
-      by = .(id_munic_7, norm_street)
-    ][n > 1],
+    command = combine_cnefe_state_component(
+      cnefe22_by_state, "st",
+      unique_key = c("id_munic_7", "norm_street")
+    ),
     format = "qs",
     storage = "worker",
     retrieval = "worker"
   ),
-  ## Create a dataset of neighborhoods in 2022 CNEFE
+  ## Create a dataset of neighborhoods in 2022 CNEFE (D6 invariant asserted)
   tar_target(
     name = cnefe22_bairro,
-    command = cnefe22[,
-      .(
-        long = median(cnefe_long, na.rm = TRUE),
-        lat = median(cnefe_lat, na.rm = TRUE),
-        n = .N
-      ),
-      by = .(id_munic_7, norm_bairro)
-    ][n > 1],
+    command = combine_cnefe_state_component(
+      cnefe22_by_state, "bairro",
+      unique_key = c("id_munic_7", "norm_bairro")
+    ),
     format = "qs",
     storage = "worker",
     retrieval = "worker"

--- a/tests/integration/equivalence_check.R
+++ b/tests/integration/equivalence_check.R
@@ -1,0 +1,267 @@
+#!/usr/bin/env Rscript
+## Dev-mode (AC/RR) equivalence harness (spec 2026-07-partition-reference-data,
+## decision D7).
+##
+## Purpose (plain language): the CNEFE reshape (issue #67) changes *how* the
+## reference aggregates are built but is meant to leave *what* they contain
+## unchanged. This script is the detector for that. It snapshots a set of target
+## values built in dev mode, and later compares a fresh build against that
+## snapshot, reporting per-target PASS/FAIL at identical() strictness.
+##
+## It is a DETECTOR, not a hard gate: acceptance is "every diff explained and
+## accepted," not "no diffs." The one expected diff in issue #67 is the
+## deliberate `norm_desc != ""` harmonization of 2010 schools, which shifts
+## `schools_cnefe10`'s row count (and possibly a few downstream match rows).
+##
+## Usage:
+##   # On master (baseline):
+##   git checkout master
+##   Rscript tests/integration/equivalence_check.R snapshot
+##
+##   # On the reshape branch:
+##   git checkout <branch>
+##   Rscript tests/integration/equivalence_check.R compare
+##
+## Each mode runs tar_make() in dev mode first, so the compared targets are
+## rebuilt from the checked-out code before they are read. Both modes use the
+## isolated dev store (_targets_dev/); the snapshot itself is written to a
+## gitignored path (see snapshot_path) so it survives the branch switch.
+##
+## Exit code is non-zero if any target FAILs the comparison, so a run can gate
+## CI once every accepted diff is encoded as an exception.
+
+Sys.setenv(TAR_PROJECT = "dev")
+suppressPackageStartupMessages({
+  library(data.table)
+  library(targets)
+})
+
+# --- Configuration -------------------------------------------------------------
+
+# Snapshot file. Lives outside the targets store and outside git tracking so it
+# persists across `tar_make()` rebuilds and `git checkout`.
+snapshot_path <- "tests/integration/.equivalence_snapshot.rds"
+
+# The targets compared (spec D7): six reference aggregates, seven match outputs,
+# plus model_data and geocoded_locais. panel_ids and trained_model are excluded
+# for the reasons given in D7 (untouched inputs; determinism given identical
+# model_data and no RNG in the matching/cleaning/panel code).
+compare_targets <- c(
+  # six reference aggregates
+  "cnefe10_st", "cnefe10_bairro",
+  "cnefe22_st", "cnefe22_bairro",
+  "schools_cnefe10", "schools_cnefe22",
+  # seven match outputs
+  "inep_string_match",
+  "schools_cnefe10_match", "schools_cnefe22_match",
+  "cnefe10_stbairro_match", "cnefe22_stbairro_match",
+  "agrocnefe_stbairro_match",
+  "geocodebr_match",
+  # modeling inputs / outputs
+  "model_data", "geocoded_locais"
+)
+
+# --- Helpers -------------------------------------------------------------------
+
+# Strip data.table internals (key, secondary indices) that are irrelevant to
+# value equality, and reduce to the underlying named list of columns. Comparing
+# as.list() with identical() gives element-wise strict comparison of column
+# names, order, types, and values while ignoring the `.internal.selfref`
+# external pointer and sort/index attributes that identical() would otherwise
+# trip on.
+as_canonical <- function(x) {
+  if (is.data.frame(x)) {
+    x <- data.table::as.data.table(x)
+    x <- data.table::copy(x)
+    data.table::setattr(x, "sorted", NULL)
+    data.table::setattr(x, "index", NULL)
+    return(as.list(x))
+  }
+  x
+}
+
+# Locate the first element at which two atomic vectors differ (NA-aware), for a
+# human-readable failure detail. Returns NULL if they are element-wise equal.
+first_diff_detail <- function(a, b) {
+  if (length(a) != length(b)) {
+    return(sprintf(
+      "row count differs (snapshot %d vs current %d)",
+      length(a), length(b)
+    ))
+  }
+  if (is.list(a) || is.list(b)) {
+    # list-columns: fall back to a coarse index scan
+    neq <- !mapply(identical, a, b)
+  } else {
+    neq <- (a != b)
+    neq[is.na(a) & is.na(b)] <- FALSE
+    neq[xor(is.na(a), is.na(b))] <- TRUE
+    neq[is.na(neq)] <- FALSE
+  }
+  idx <- which(neq)
+  if (!length(idx)) {
+    return(NULL)
+  }
+  i <- idx[1]
+  sprintf(
+    "first differs at row %d (snapshot=%s, current=%s)",
+    i, format(a[[i]]), format(b[[i]])
+  )
+}
+
+# Compare one target's snapshot value against its current value. Returns a list
+# with pass (logical) and detail (character, "" when passing).
+compare_one <- function(name, snap, cur) {
+  # "unavailable": one side is missing (target failed to build, or is absent from
+  # the snapshot). This is a "could not verify," reported distinctly from a real
+  # value diff so a broken-upstream target does not masquerade as a detected diff.
+  if (is.null(snap)) {
+    return(list(status = "unavailable", detail = "absent from snapshot"))
+  }
+  if (is.null(cur)) {
+    return(list(status = "unavailable", detail = "absent from current build"))
+  }
+
+  snap_c <- as_canonical(snap)
+  cur_c <- as_canonical(cur)
+
+  # Non-tabular fallback: compare the canonical objects directly.
+  if (!is.list(snap_c) || is.null(names(snap_c))) {
+    if (identical(snap_c, cur_c)) {
+      return(list(status = "pass", detail = ""))
+    }
+    return(list(status = "diff", detail = "values differ (non-tabular)"))
+  }
+
+  if (!identical(names(snap_c), names(cur_c))) {
+    return(list(status = "diff", detail = sprintf(
+      "column set/order differs: snapshot=[%s] current=[%s]",
+      paste(names(snap_c), collapse = ", "),
+      paste(names(cur_c), collapse = ", ")
+    )))
+  }
+
+  for (col in names(snap_c)) {
+    if (!identical(snap_c[[col]], cur_c[[col]])) {
+      detail <- first_diff_detail(snap_c[[col]], cur_c[[col]])
+      if (is.null(detail)) {
+        # identical() FALSE but element-wise equal -> a type/attribute-level
+        # difference (e.g. integer vs double storage). Surface it plainly.
+        detail <- sprintf(
+          "types differ (snapshot=%s, current=%s)",
+          paste(class(snap_c[[col]]), collapse = "/"),
+          paste(class(cur_c[[col]]), collapse = "/")
+        )
+      }
+      return(list(
+        status = "diff",
+        detail = sprintf("column '%s': %s", col, detail)
+      ))
+    }
+  }
+
+  list(status = "pass", detail = "")
+}
+
+# --- Build the compared targets from the checked-out code ----------------------
+
+mode <- commandArgs(trailingOnly = TRUE)[1]
+if (is.na(mode) || !mode %in% c("snapshot", "compare")) {
+  stop("Usage: equivalence_check.R [snapshot|compare]")
+}
+
+message("Building dev-mode compared targets (this takes minutes)...")
+# Build each target independently and tolerate failures: if one target (or its
+# upstream) is broken for a reason unrelated to this change, the others are still
+# built and compared, and the broken one is reported as "BUILD FAILED" rather
+# than aborting the whole run. callr_function = NULL runs the pipeline in this
+# process so `compare_targets` (a local variable) is in scope for the tidyselect
+# `names` expression; the default callr subprocess would not see it.
+read_all <- function(names) {
+  vals <- lapply(names, function(nm) {
+    ok <- tryCatch({
+      tar_make(names = tidyselect::all_of(nm), callr_function = NULL)
+      TRUE
+    }, error = function(e) {
+      message(sprintf("BUILD FAILED for %s: %s", nm, conditionMessage(e)))
+      FALSE
+    })
+    if (!ok) {
+      return(NULL)
+    }
+    tryCatch(tar_read_raw(nm), error = function(e) NULL)
+  })
+  names(vals) <- names
+  vals
+}
+
+current <- read_all(compare_targets)
+
+# --- Snapshot mode -------------------------------------------------------------
+
+if (mode == "snapshot") {
+  saveRDS(current, snapshot_path)
+  cat(sprintf(
+    "Snapshot written to %s (%d targets).\n",
+    snapshot_path, length(current)
+  ))
+  quit(status = 0)
+}
+
+# --- Compare mode --------------------------------------------------------------
+
+if (!file.exists(snapshot_path)) {
+  stop(sprintf(
+    "No snapshot at %s. Run `equivalence_check.R snapshot` on the baseline first.",
+    snapshot_path
+  ))
+}
+snapshot <- readRDS(snapshot_path)
+
+cat("\n=== Equivalence comparison (identical() strictness) ===\n")
+statuses <- vapply(compare_targets, function(nm) {
+  res <- compare_one(nm, snapshot[[nm]], current[[nm]])
+  label <- switch(res$status,
+    pass = "PASS ",
+    diff = "DIFF ",
+    unavailable = "UNAVL"
+  )
+  if (nzchar(res$detail)) {
+    cat(sprintf("%s %s -- %s\n", label, nm, res$detail))
+  } else {
+    cat(sprintf("%s %s\n", label, nm))
+  }
+  res$status
+}, character(1))
+
+n_pass <- sum(statuses == "pass")
+n_diff <- sum(statuses == "diff")
+n_unavail <- sum(statuses == "unavailable")
+cat(sprintf(
+  "\n%d identical, %d differ, %d unavailable (of %d).\n",
+  n_pass, n_diff, n_unavail, length(statuses)
+))
+if (n_unavail > 0) {
+  cat(sprintf(
+    paste0(
+      "%d target(s) could not be built/compared (see UNAVL above) -- likely a ",
+      "broken upstream unrelated to this change. Rerun in an environment where ",
+      "they build to complete the gate.\n"
+    ),
+    n_unavail
+  ))
+}
+if (n_diff > 0) {
+  cat(sprintf(
+    paste0(
+      "%d target(s) differ. This is expected iff every diff is an accepted, ",
+      "documented behavior change (e.g. the 2010 `norm_desc` harmonization). ",
+      "Review each DIFF above before accepting.\n"
+    ),
+    n_diff
+  ))
+}
+if (n_diff > 0 || n_unavail > 0) {
+  quit(status = 1)
+}
+cat("All compared targets are identical to the snapshot.\n")

--- a/tests/integration/equivalence_check.R
+++ b/tests/integration/equivalence_check.R
@@ -70,12 +70,11 @@ compare_targets <- c(
 # external pointer and sort/index attributes that identical() would otherwise
 # trip on.
 as_canonical <- function(x) {
+  # as.list() on a data.table returns a plain named list of the column vectors,
+  # dropping the key/index/selfref attributes that identical() would otherwise
+  # trip on -- so no explicit attribute stripping is needed.
   if (is.data.frame(x)) {
-    x <- data.table::as.data.table(x)
-    x <- data.table::copy(x)
-    data.table::setattr(x, "sorted", NULL)
-    data.table::setattr(x, "index", NULL)
-    return(as.list(x))
+    return(as.list(data.table::as.data.table(x)))
   }
   x
 }
@@ -93,10 +92,8 @@ first_diff_detail <- function(a, b) {
     # list-columns: fall back to a coarse index scan
     neq <- !mapply(identical, a, b)
   } else {
-    neq <- (a != b)
-    neq[is.na(a) & is.na(b)] <- FALSE
-    neq[xor(is.na(a), is.na(b))] <- TRUE
-    neq[is.na(neq)] <- FALSE
+    # differ iff exactly one side is NA, or both are non-NA and unequal
+    neq <- xor(is.na(a), is.na(b)) | (!is.na(a) & !is.na(b) & a != b)
   }
   idx <- which(neq)
   if (!length(idx)) {

--- a/tests/integration/equivalence_check.R
+++ b/tests/integration/equivalence_check.R
@@ -14,21 +14,25 @@
 ## `schools_cnefe10`'s row count (and possibly a few downstream match rows).
 ##
 ## Usage:
-##   # On master (baseline):
-##   git checkout master
-##   Rscript tests/integration/equivalence_check.R snapshot
+##   # This script reads target VALUES from the store, so it runs correctly
+##   # against any checked-out code -- but the file itself lives only on the
+##   # reshape branch. Copy it somewhere stable first so it survives the checkout
+##   # onto master (where it does not exist):
+##   cp tests/integration/equivalence_check.R /tmp/equivalence_check.R
 ##
-##   # On the reshape branch:
-##   git checkout <branch>
-##   Rscript tests/integration/equivalence_check.R compare
+##   # Baseline snapshot on master:
+##   git checkout master && Rscript /tmp/equivalence_check.R snapshot
+##
+##   # Rebuild + compare on the reshape branch:
+##   git checkout <branch> && Rscript /tmp/equivalence_check.R compare
 ##
 ## Each mode runs tar_make() in dev mode first, so the compared targets are
 ## rebuilt from the checked-out code before they are read. Both modes use the
 ## isolated dev store (_targets_dev/); the snapshot itself is written to a
 ## gitignored path (see snapshot_path) so it survives the branch switch.
 ##
-## Exit code is non-zero if any target FAILs the comparison, so a run can gate
-## CI once every accepted diff is encoded as an exception.
+## Exit code is non-zero if any target DIFFs or is UNAVAILABLE, so a run can gate
+## CI once every accepted diff is reviewed.
 
 Sys.setenv(TAR_PROJECT = "dev")
 suppressPackageStartupMessages({

--- a/tests/testthat/test-aggregate_cnefe_coords.R
+++ b/tests/testthat/test-aggregate_cnefe_coords.R
@@ -8,7 +8,7 @@
 
 library(data.table)
 
-test_that("aggregate_cnefe_coords takes group medians and drops singletons", {
+test_that("aggregate_cnefe_coords takes group medians and keeps singletons", {
   addr <- data.table(
     id_munic_7 = c(1L, 1L, 1L, 1L),
     norm_street = c("rua a", "rua a", "rua a", "rua b"),
@@ -17,12 +17,12 @@ test_that("aggregate_cnefe_coords takes group medians and drops singletons", {
   )
   out <- aggregate_cnefe_coords(addr, "norm_street")
 
-  # "rua b" appears once (n == 1) and is dropped; only "rua a" survives.
-  expect_equal(nrow(out), 1L)
-  expect_equal(out$norm_street, "rua a")
-  expect_equal(out$n, 3L)
-  expect_equal(out$long, median(c(-60, -62, -64)))
-  expect_equal(out$lat, -8)
+  # Both groups are kept here (including the n == 1 "rua b"); the singleton drop
+  # happens later in combine_cnefe_state_component(), after the duplicate check.
+  expect_equal(nrow(out), 2L)
+  expect_equal(out[norm_street == "rua a"]$n, 3L)
+  expect_equal(out[norm_street == "rua a"]$long, median(c(-60, -62, -64)))
+  expect_equal(out[norm_street == "rua b"]$n, 1L)
   expect_equal(names(out), c("id_munic_7", "norm_street", "long", "lat", "n"))
 })
 
@@ -102,4 +102,44 @@ test_that("combine_cnefe_state_component stops on a cross-slice duplicate key", 
     ),
     "duplicated across"
   )
+})
+
+test_that("combine_cnefe_state_component catches a 1+1 cross-slice split", {
+  # A key that appears exactly once in each of two slices (n == 1 per state) is
+  # the case the per-state [n > 1] filter used to hide: both singletons would be
+  # dropped before the invariant could see them. The check must fire before the
+  # singleton drop. (Also confirms the surviving n > 1 groups are still thinned.)
+  state_results <- list(
+    list(st = data.table(
+      id_munic_7 = c(1L, 9L), norm_street = c("x", "keep"),
+      long = c(1, 1), lat = c(1, 1), n = c(1L, 2L)
+    )),
+    list(st = data.table(
+      id_munic_7 = 1L, norm_street = "x", long = 2, lat = 2, n = 1L
+    ))
+  )
+  expect_error(
+    combine_cnefe_state_component(
+      state_results, "st",
+      unique_key = c("id_munic_7", "norm_street")
+    ),
+    "duplicated across"
+  )
+})
+
+test_that("combine_cnefe_state_component drops singletons after the check", {
+  # No cross-slice duplicate: the check passes, then n == 1 groups are dropped
+  # and only n > 1 groups survive (matching the national [n > 1] filter).
+  state_results <- list(
+    list(st = data.table(
+      id_munic_7 = c(1L, 1L), norm_street = c("keep", "solo"),
+      long = c(1, 2), lat = c(1, 2), n = c(4L, 1L)
+    ))
+  )
+  out <- combine_cnefe_state_component(
+    state_results, "st",
+    unique_key = c("id_munic_7", "norm_street")
+  )
+  expect_equal(out$norm_street, "keep")
+  expect_equal(out$n, 4L)
 })

--- a/tests/testthat/test-aggregate_cnefe_coords.R
+++ b/tests/testthat/test-aggregate_cnefe_coords.R
@@ -1,0 +1,105 @@
+## Spec tests for the fused CNEFE aggregation helpers (R/utilities.R),
+## introduced by the #67 reshape (spec 2026-07-partition-reference-data, D5/D6).
+##
+## aggregate_cnefe_coords() collapses cleaned CNEFE rows to per-municipality
+## group medians, keeping only groups seen more than once. combine_cnefe_state_
+## component() row-binds a named component across per-state results and asserts
+## the D6 no-cross-state-duplicate invariant for keyed aggregates.
+
+library(data.table)
+
+test_that("aggregate_cnefe_coords takes group medians and drops singletons", {
+  addr <- data.table(
+    id_munic_7 = c(1L, 1L, 1L, 1L),
+    norm_street = c("rua a", "rua a", "rua a", "rua b"),
+    cnefe_long = c(-60, -62, -64, -50),
+    cnefe_lat = c(-8, -8, -8, -9)
+  )
+  out <- aggregate_cnefe_coords(addr, "norm_street")
+
+  # "rua b" appears once (n == 1) and is dropped; only "rua a" survives.
+  expect_equal(nrow(out), 1L)
+  expect_equal(out$norm_street, "rua a")
+  expect_equal(out$n, 3L)
+  expect_equal(out$long, median(c(-60, -62, -64)))
+  expect_equal(out$lat, -8)
+  expect_equal(names(out), c("id_munic_7", "norm_street", "long", "lat", "n"))
+})
+
+test_that("aggregate_cnefe_coords ignores NA coordinates in the median", {
+  addr <- data.table(
+    id_munic_7 = c(5L, 5L, 5L),
+    norm_bairro = c("centro", "centro", "centro"),
+    cnefe_long = c(-60, NA, -64),
+    cnefe_lat = c(-8, -8, NA)
+  )
+  out <- aggregate_cnefe_coords(addr, "norm_bairro")
+
+  expect_equal(out$long, median(c(-60, -64)))
+  expect_equal(out$lat, -8)
+  expect_equal(out$n, 3L)
+})
+
+test_that("per-state aggregate + combine equals national aggregate", {
+  # Keys never span states, so aggregating each state then row-binding must
+  # reproduce aggregating the concatenated national table (the old path).
+  s1 <- data.table(
+    id_munic_7 = c(1L, 1L, 2L, 2L, 2L),
+    norm_street = c("rua a", "rua a", "rua c", "rua c", "rua d"),
+    cnefe_long = c(-60, -61, -50, -52, -40),
+    cnefe_lat = c(-8, -8, -9, -9, -7)
+  )
+  s2 <- data.table(
+    id_munic_7 = c(3L, 3L, 3L),
+    norm_street = c("rua e", "rua e", "rua f"),
+    cnefe_long = c(-30, -32, -20),
+    cnefe_lat = c(-6, -6, -5)
+  )
+
+  national <- rbindlist(list(s1, s2))
+  old <- national[
+    ,
+    .(long = median(cnefe_long, na.rm = TRUE),
+      lat = median(cnefe_lat, na.rm = TRUE), n = .N),
+    by = .(id_munic_7, norm_street)
+  ][n > 1]
+
+  state_results <- list(
+    list(st = aggregate_cnefe_coords(s1, "norm_street")),
+    list(st = aggregate_cnefe_coords(s2, "norm_street"))
+  )
+  new <- combine_cnefe_state_component(
+    state_results, "st",
+    unique_key = c("id_munic_7", "norm_street")
+  )
+
+  expect_identical(as.list(old), as.list(new))
+})
+
+test_that("combine_cnefe_state_component row-binds schools without a key check", {
+  # Schools are legitimately many-per-municipality; no uniqueness invariant.
+  state_results <- list(
+    list(schools = data.table(id_munic_7 = c(1L, 1L), norm_desc = c("a", "b"))),
+    list(schools = data.table(id_munic_7 = c(1L, 2L), norm_desc = c("a", "c")))
+  )
+  out <- combine_cnefe_state_component(state_results, "schools")
+  expect_equal(nrow(out), 4L)
+})
+
+test_that("combine_cnefe_state_component stops on a cross-slice duplicate key", {
+  # The same (id_munic_7, norm_street) in two slices is exactly what a
+  # municipality spanning two state files would produce (D6).
+  state_results <- list(
+    list(st = data.table(id_munic_7 = 1L, norm_street = "x",
+                         long = 1, lat = 1, n = 3L)),
+    list(st = data.table(id_munic_7 = 1L, norm_street = "x",
+                         long = 2, lat = 2, n = 5L))
+  )
+  expect_error(
+    combine_cnefe_state_component(
+      state_results, "st",
+      unique_key = c("id_munic_7", "norm_street")
+    ),
+    "duplicated across"
+  )
+})


### PR DESCRIPTION
## What this does (plain language)

The pipeline used to glue every state's cleaned census (CNEFE) data into two
huge national tables (`cnefe10`, `cnefe22`, tens of gigabytes each) just to boil
them down to small per-municipality summary tables — and it read and cleaned the
2010 census twice, once for the address rows and once again for schools. This PR
computes those small summaries **inside each state's cleaning step** and throws
the bulky per-state address rows away immediately. The giant national tables and
the duplicate 2010 pass are deleted. This is the primary memory win of the #62
reshape and it ships on its own.

Closes #67.

## What changed

- **`process_cnefe_state()`** (`R/utilities.R`) now returns
  `list(st, bairro, schools)` computed in memory. The full cleaned address table
  is never returned and never persisted (spec D5). 2010 schools come from the
  same `clean_cnefe10(extract_schools = TRUE)` pass, so the separate
  `schools_cnefe10_by_state` target (~12,000 s of duplicated work) is gone.
- **Two new pure helpers:** `aggregate_cnefe_coords()` (per-municipality group
  medians) and `combine_cnefe_state_component()` (row-bind one component across
  states and assert the D6 no-cross-state-duplicate-key invariant).
- **`_targets.R`:** deleted `cnefe10`, `cnefe22`, and `schools_cnefe10_by_state`.
  The six reference aggregates (`cnefe10_st/bairro`, `cnefe22_st/bairro`,
  `schools_cnefe10/22`) keep their names and output shapes, so every downstream
  target is untouched. Cleaning stays on the `memory_limited` controller.
- **Deliberate behavior change, own commit:** 2010 schools now drop rows with an
  empty normalized description (`norm_desc != ""`), harmonizing with the 2022
  path (spec D7). This is the one accepted, documented output change.
- **Equivalence harness** (`tests/integration/equivalence_check.R`, spec D7):
  `snapshot`/`compare` modes comparing the six aggregates, seven match outputs,
  `model_data`, and `geocoded_locais` at `identical()` strictness. It tolerates
  targets that fail to build for unrelated reasons, reporting them as
  UNAVAILABLE rather than aborting.
- **Unit tests** for the two new helpers, including the D6 invariant and the
  1+1-split regression.

## Verification (dev-mode AC/RR equivalence gate)

Snapshot on master, rebuild on the branch, compare (spec D7 — acceptance is
"every diff explained and accepted," not "no diffs"):

- **Structural reshape vs master:** all six reference aggregates **identical**.
- **After the `norm_desc` commit vs master:** five aggregates identical; only
  `schools_cnefe10` differs (2548 → 2009 rows in AC/RR — the empty-description
  school rows). `schools_cnefe22` is unchanged, confirming the change is isolated
  to 2010. This is the single expected, documented diff.

The seven match outputs, `model_data`, and `geocoded_locais` could **not** be
compared in dev mode here because of a pre-existing, unrelated blocker filed as
**#70** (`locais_all` merges the full national import against the dev-filtered
`muni_ids`, tripping the `local_id` uniqueness invariant). Per spec D7 the first
production run after merge diffs against the shipped release files and covers
that downstream half.

## Review layers

`/simplify` (4 agents) and a Codex review both ran. `/simplify` applied three
quality cleanups (committed as the "/simplify pass" commit). Codex surfaced a
real robustness gap — the per-state singleton filter hid a 1+1 cross-state split
from the D6 invariant — fixed in the last commit by moving the singleton drop to
after the duplicate check (output unchanged; new regression test added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)