### PR TITLE
Fix dev-mode locais_all merge against dev-filtered muni_ids (#70)

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -477,7 +477,12 @@ list(
     name = locais_all,
     command = import_locais(
       locais_file = locais_file,
-      muni_ids = muni_ids
+      # locais_all is the pre-dev-filter national import, so it must merge against
+      # the unfiltered national crosswalk. Using dev-filtered muni_ids here would
+      # leave non-dev stations with cod_localidade_ibge = NA, colliding on the
+      # deterministic local_id key (#70). Dev subsetting happens downstream in the
+      # `locais` target via apply_dev_mode_filters().
+      muni_ids = muni_ids_all
     ),
     format = "qs",
     storage = "worker",


### PR DESCRIPTION
## Purpose

Dev-mode pipeline builds (`TAR_PROJECT=dev tar_make()`) were failing at the `locais_all` target with a "local_id key not unique: 684,737 duplicate rows" error, which blocked every downstream match/model/export target and the `dev_pipeline_check.R` integration test. This PR restores dev-mode builds. Production was never affected.

## What was wrong

`locais_all` is the **national** polling-station import that happens *before* dev-mode subsetting. It attaches each station's municipality code by joining the `muni_ids` crosswalk — but `muni_ids` is dev-filtered down to the two dev states (AC/RR). So in dev mode the join only resolved municipality codes for AC/RR stations; every other station got `cod_localidade_ibge = NA`. The deterministic `local_id` invariant (added for #36/#48) then saw the key `(ano, NA, nr_zona, nr_locvot)` collide across all non-dev municipalities and stopped the build.

## The fix

Merge `locais_all` against the unfiltered national crosswalk `muni_ids_all` instead of the dev-filtered `muni_ids`. Dev subsetting still happens downstream in the `locais` target via `apply_dev_mode_filters()`, so dev mode still only processes AC/RR. Production is unchanged (there `muni_ids` already equals the national table).

Closes #70.

## Verification

- `TAR_PROJECT=dev` builds `locais_all` cleanly (invariant holds).
- Downstream `locais_filtered` builds with 10,006 rows, only AC/RR states, and 0 NA municipality codes.
- Codex review found no introduced bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)