### PR TITLE
Delete dead batch_type column in create_panel_municipality_batches

### DIFF
--- a/R/panel_creation.R
+++ b/R/panel_creation.R
@@ -318,16 +318,7 @@ create_panel_municipality_batches <- function(locais_data, target_batch_size = 5
     muni_counts[is.na(batch_id) | batch_id == 0, batch_id := remaining$batch_id]
   }
 
-  # Add batch type for controller selection
-  muni_counts[,
-    batch_type := fcase(
-      size_class == "mega"  , "mega_cities"    ,
-      size_class == "large" , "memory_limited" ,
-      default = "standard"
-    )
-  ]
-
-  return(muni_counts[, .(cod_localidade_ibge, sg_uf, n_stations, batch_id, batch_type, size_class)])
+  return(muni_counts[, .(cod_localidade_ibge, sg_uf, n_stations, batch_id, size_class)])
 }
 
 #' Process panel IDs for a batch of municipalities


### PR DESCRIPTION
## What this does

`create_panel_municipality_batches()` computed a `batch_type` column
(labeling each municipality batch "mega_cities", "memory_limited", or
"standard") that was meant to route batches to different parallel-processing
controllers. Nothing ever read that column — it was dead code. This PR
deletes the computation and drops the column from the returned table.

Wiring it up instead was considered and rejected during the #62 grilling
(spec `docs/specs/2026-07-partition-reference-data-spec.md`, decision D3):
the panel stage already runs entirely on the `standard` controller, and
per-branch controller routing is not possible under dynamic branching.

## Verification

- `grep` confirms nothing in `R/`, `_targets.R`, or `tests/` reads `batch_type` (only historical mentions remain in the spec doc).
- Fast unit tests pass: `[ FAIL 0 | WARN 0 | SKIP 1 | PASS 279 ]`.
- Dev-mode build of `panel_municipality_batches` completes; returned columns are now `cod_localidade_ibge, sg_uf, n_stations, batch_id, size_class`.

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4oi1wqC8mCDaFmBM7SHhW