### PR TITLE
Partition CNEFE-family reference tables into per-batch slices (#68)

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -311,25 +311,104 @@ combine_cnefe_state_component <- function(state_results, component, unique_key =
   combined
 }
 
+#' Slice a reference table into per-batch groups for Option A branching (issue #68)
+#'
+#' Attaches each reference row's `batch_id` (via `municipality_batch_assignments`,
+#' the single source of truth for the municipality->batch map) plus a contiguous
+#' `tar_group`, so a match target can `pattern = map()` over the groups with
+#' `retrieval = "main"` and receive only its batch's slice instead of the whole
+#' national reference table.
+#'
+#' The join is an update-join (it does not reorder rows) followed by an
+#' inner-join drop: reference municipalities absent from the batch assignments
+#' have no polling stations and are never matched, so dropping them changes no
+#' match output. `tar_group` is the dense rank of `batch_id`, which is a
+#' contiguous 1..N in ascending `batch_id` order (the pre-existing branch order)
+#' and leaves row order untouched -- so every per-municipality slice preserves the
+#' reference's original row order and therefore identical match tie-breaks.
+#'
+#' @param ref data.table reference table (must have `id_munic_7`).
+#' @param municipality_batch_assignments data.table with `cod_localidade_ibge`,
+#'   `batch_id`.
+#' @return `ref` (inner-joined to the assignments) with added `batch_id` and
+#'   `tar_group` columns, intended for `iteration = "group"`.
+#' @export
+make_ref_batch_groups <- function(ref, municipality_batch_assignments) {
+  ref <- data.table::copy(ref)
+  ref[
+    municipality_batch_assignments,
+    batch_id := i.batch_id,
+    on = c(id_munic_7 = "cod_localidade_ibge")
+  ]
+  # Inner-join semantics: a reference municipality with no polling-station batch
+  # is never matched, so drop it rather than form an empty group for it.
+  ref <- ref[!is.na(batch_id)]
+  if (nrow(ref) == 0L) {
+    # Degenerate case: no reference municipality overlaps the batch assignments,
+    # so this reference contributes no matches at all. (Dev mode hits this for
+    # Agro CNEFE, whose municipality codes do not intersect the AC/RR polling
+    # municipalities.) `pattern = map()` cannot branch over an empty target, so
+    # emit one placeholder group carrying no real municipality (id_munic_7 = NA).
+    # The match batch then runs once, every per-municipality lookup misses, and
+    # the combined result is the same empty data.table the whole-table path
+    # produced -- equivalence preserved, no crash.
+    ref <- ref[NA_integer_]
+    ref[, batch_id := municipality_batch_assignments$batch_id[1]]
+  }
+  ref[, tar_group := data.table::frank(batch_id, ties.method = "dense")]
+  ref[]
+}
+
+#' Slice paired street + neighborhood reference tables into per-batch groups (#68)
+#'
+#' Unions the street and neighborhood aggregates (tagged by a `component` column)
+#' into one table before grouping, so both travel as a single grouped stem and
+#' cannot fall out of group alignment -- which mapping over two separate grouped
+#' targets would risk whenever a batch has streets but no neighborhoods, or vice
+#' versa. Grouping semantics are those of [make_ref_batch_groups()].
+#'
+#' @param ref_st Street-level aggregate (`id_munic_7`, `norm_street`, `long`,
+#'   `lat`, `n`).
+#' @param ref_bairro Neighborhood-level aggregate (`id_munic_7`, `norm_bairro`,
+#'   `long`, `lat`, `n`).
+#' @param municipality_batch_assignments data.table with `cod_localidade_ibge`,
+#'   `batch_id`.
+#' @return Unioned table with a `component` tag (`"st"`/`"bairro"`) plus
+#'   `batch_id`/`tar_group`, intended for `iteration = "group"`.
+#' @export
+make_stbairro_batch_groups <- function(ref_st, ref_bairro, municipality_batch_assignments) {
+  st <- data.table::copy(ref_st)[, component := "st"]
+  bairro <- data.table::copy(ref_bairro)[, component := "bairro"]
+  ref <- data.table::rbindlist(list(st, bairro), use.names = TRUE, fill = TRUE)
+  make_ref_batch_groups(ref, municipality_batch_assignments)
+}
+
 #' Process INEP string matching in batches
 #'
-#' @param batch_ids Current batch ID
+#' `inep_data` is a per-batch grouped-stem slice (Option A, issue #68): the
+#' production INEP catalog is ~61 MB, so slicing it (rather than broadcasting the
+#' whole table to every worker) clears the D3 size bar. Municipalities are still
+#' taken from `municipality_batch_assignments` so the combined row order is
+#' byte-identical to the pre-reshape pipeline.
+#'
 #' @param municipality_batch_assignments Batch assignments
 #' @param locais_filtered Filtered polling stations
-#' @param inep_data INEP data
+#' @param inep_data Per-batch slice of the INEP catalog
 #' @return Combined match results
 #' @export
-process_inep_batch <- function(batch_ids, municipality_batch_assignments, locais_filtered, inep_data) {
-  # Get municipalities for this batch
+process_inep_batch <- function(municipality_batch_assignments, locais_filtered, inep_data) {
+  this_batch <- inep_data$batch_id[1]
   batch_munis <- municipality_batch_assignments[
-    batch_id == batch_ids
+    batch_id == this_batch
   ]$cod_localidade_ibge
+
+  data.table::setkey(inep_data, id_munic_7)
 
   # Process all municipalities in this batch
   batch_results <- lapply(batch_munis, function(muni_code) {
     match_inep_muni(
       locais_muni = locais_filtered[cod_localidade_ibge == muni_code],
-      inep_muni = inep_data[id_munic_7 == muni_code]
+      inep_muni = inep_data[.(muni_code), nomatch = NULL]
     )
   })
 
@@ -344,23 +423,30 @@ process_inep_batch <- function(batch_ids, municipality_batch_assignments, locais
 
 #' Process schools CNEFE string matching in batches
 #'
-#' @param batch_ids Current batch ID
+#' `schools_cnefe` is a per-batch grouped-stem slice (Option A, issue #68): it
+#' holds only this batch's municipalities plus a constant `batch_id` column, so
+#' the whole national table never crosses to the worker. Municipalities are still
+#' taken from `municipality_batch_assignments` (the source of truth) so per-batch
+#' iteration order -- and thus the combined row order -- is byte-identical to the
+#' pre-reshape pipeline.
+#'
 #' @param municipality_batch_assignments Batch assignments
 #' @param locais_filtered Filtered polling stations
-#' @param schools_cnefe Schools CNEFE data
+#' @param schools_cnefe Per-batch slice of the schools CNEFE reference
 #' @return Combined match results
 #' @export
-process_schools_cnefe_batch <- function(batch_ids, municipality_batch_assignments, locais_filtered, schools_cnefe) {
-  # Get municipalities for this batch
+process_schools_cnefe_batch <- function(municipality_batch_assignments, locais_filtered, schools_cnefe) {
+  this_batch <- schools_cnefe$batch_id[1]
   batch_munis <- municipality_batch_assignments[
-    batch_id == batch_ids
+    batch_id == this_batch
   ]$cod_localidade_ibge
 
-  # Process all municipalities in this batch
+  data.table::setkey(schools_cnefe, id_munic_7)
+
   batch_results <- lapply(batch_munis, function(muni_code) {
     match_schools_cnefe_muni(
       locais_muni = locais_filtered[cod_localidade_ibge == muni_code],
-      schools_cnefe_muni = schools_cnefe[id_munic_7 == muni_code]
+      schools_cnefe_muni = schools_cnefe[.(muni_code), nomatch = NULL]
     )
   })
 
@@ -410,29 +496,38 @@ process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, l
 
 #' Process CNEFE street/neighborhood matching in batches
 #'
-#' @param batch_ids Current batch ID
+#' `cnefe_stbairro` is a per-batch grouped-stem slice (Option A, issue #68): the
+#' union of the street and neighborhood aggregates for this batch's
+#' municipalities, tagged by `component` and carrying a constant `batch_id`. The
+#' whole national tables never cross to the worker; municipalities are still
+#' taken from `municipality_batch_assignments` so the combined row order is
+#' byte-identical to the pre-reshape pipeline.
+#'
 #' @param municipality_batch_assignments Batch assignments
 #' @param locais_filtered Filtered polling stations
-#' @param cnefe_st Street-level CNEFE data
-#' @param cnefe_bairro Neighborhood-level CNEFE data
+#' @param cnefe_stbairro Per-batch slice: union of street + neighborhood CNEFE
+#'   aggregates, tagged by `component`
 #' @return Combined match results
 #' @export
 process_cnefe_stbairro_batch <- function(
-  batch_ids,
   municipality_batch_assignments,
   locais_filtered,
-  cnefe_st,
-  cnefe_bairro
+  cnefe_stbairro
 ) {
-  # Get municipalities for this batch
+  this_batch <- cnefe_stbairro$batch_id[1]
   batch_munis <- municipality_batch_assignments[
-    batch_id == batch_ids
+    batch_id == this_batch
   ]$cod_localidade_ibge
+
+  cnefe_st <- cnefe_stbairro[component == "st"]
+  cnefe_bairro <- cnefe_stbairro[component == "bairro"]
+  data.table::setkey(cnefe_st, id_munic_7)
+  data.table::setkey(cnefe_bairro, id_munic_7)
 
   # Log batch start
   message(sprintf(
     "[Batch %d] Starting CNEFE street/neighborhood matching for %d municipalities",
-    batch_ids,
+    this_batch,
     length(batch_munis)
   ))
 
@@ -440,34 +535,32 @@ process_cnefe_stbairro_batch <- function(
   batch_results <- lapply(seq_along(batch_munis), function(i) {
     muni_code <- batch_munis[i]
 
-    # Get data sizes for logging
-    n_locais <- nrow(locais_filtered[cod_localidade_ibge == muni_code])
-    n_streets <- nrow(cnefe_st[id_munic_7 == muni_code])
-    n_bairros <- nrow(cnefe_bairro[id_munic_7 == muni_code])
+    cnefe_st_muni <- cnefe_st[.(muni_code), nomatch = NULL]
+    cnefe_bairro_muni <- cnefe_bairro[.(muni_code), nomatch = NULL]
 
     message(sprintf(
       "[Batch %d - %d/%d] Processing municipality %s: %d polling stations, %d streets, %d neighborhoods",
-      batch_ids,
+      this_batch,
       i,
       length(batch_munis),
       muni_code,
-      n_locais,
-      n_streets,
-      n_bairros
+      nrow(locais_filtered[cod_localidade_ibge == muni_code]),
+      nrow(cnefe_st_muni),
+      nrow(cnefe_bairro_muni)
     ))
 
     # Perform matching
     result <- match_stbairro_cnefe_muni(
       locais_muni = locais_filtered[cod_localidade_ibge == muni_code],
-      cnefe_st_muni = cnefe_st[id_munic_7 == muni_code],
-      cnefe_bairro_muni = cnefe_bairro[id_munic_7 == muni_code]
+      cnefe_st_muni = cnefe_st_muni,
+      cnefe_bairro_muni = cnefe_bairro_muni
     )
 
     # Log completion
     if (!is.null(result)) {
       message(sprintf(
         "[Batch %d - %d/%d] Completed municipality %s: %d matches",
-        batch_ids,
+        this_batch,
         i,
         length(batch_munis),
         muni_code,
@@ -490,7 +583,7 @@ process_cnefe_stbairro_batch <- function(
 
   message(sprintf(
     "[Batch %d] Completed with %d total matches from %d municipalities",
-    batch_ids,
+    this_batch,
     total_matches,
     length(batch_results)
   ))
@@ -504,29 +597,37 @@ process_cnefe_stbairro_batch <- function(
 
 #' Process Agro CNEFE street/neighborhood matching in batches
 #'
-#' @param batch_ids Current batch ID
+#' `agrocnefe_stbairro` is a per-batch grouped-stem slice (Option A, issue #68):
+#' the union of the street and neighborhood aggregates for this batch's
+#' municipalities, tagged by `component` and carrying a constant `batch_id`.
+#' Municipalities are still taken from `municipality_batch_assignments` so the
+#' combined row order is byte-identical to the pre-reshape pipeline.
+#'
 #' @param municipality_batch_assignments Batch assignments
 #' @param locais_filtered Filtered polling stations
-#' @param agrocnefe_st Street-level Agro CNEFE data
-#' @param agrocnefe_bairro Neighborhood-level Agro CNEFE data
+#' @param agrocnefe_stbairro Per-batch slice: union of street + neighborhood Agro
+#'   CNEFE aggregates, tagged by `component`
 #' @return Combined match results
 #' @export
 process_agrocnefe_stbairro_batch <- function(
-  batch_ids,
   municipality_batch_assignments,
   locais_filtered,
-  agrocnefe_st,
-  agrocnefe_bairro
+  agrocnefe_stbairro
 ) {
-  # Get municipalities for this batch
+  this_batch <- agrocnefe_stbairro$batch_id[1]
   batch_munis <- municipality_batch_assignments[
-    batch_id == batch_ids
+    batch_id == this_batch
   ]$cod_localidade_ibge
+
+  agrocnefe_st <- agrocnefe_stbairro[component == "st"]
+  agrocnefe_bairro <- agrocnefe_stbairro[component == "bairro"]
+  data.table::setkey(agrocnefe_st, id_munic_7)
+  data.table::setkey(agrocnefe_bairro, id_munic_7)
 
   # Log batch start
   message(sprintf(
     "[Batch %d] Starting Agro CNEFE street/neighborhood matching for %d municipalities",
-    batch_ids,
+    this_batch,
     length(batch_munis)
   ))
 
@@ -534,34 +635,32 @@ process_agrocnefe_stbairro_batch <- function(
   batch_results <- lapply(seq_along(batch_munis), function(i) {
     muni_code <- batch_munis[i]
 
-    # Get data sizes for logging
-    n_locais <- nrow(locais_filtered[cod_localidade_ibge == muni_code])
-    n_streets <- nrow(agrocnefe_st[id_munic_7 == muni_code])
-    n_bairros <- nrow(agrocnefe_bairro[id_munic_7 == muni_code])
+    agrocnefe_st_muni <- agrocnefe_st[.(muni_code), nomatch = NULL]
+    agrocnefe_bairro_muni <- agrocnefe_bairro[.(muni_code), nomatch = NULL]
 
     message(sprintf(
       "[Batch %d - %d/%d] Processing municipality %s: %d polling stations, %d streets, %d neighborhoods",
-      batch_ids,
+      this_batch,
       i,
       length(batch_munis),
       muni_code,
-      n_locais,
-      n_streets,
-      n_bairros
+      nrow(locais_filtered[cod_localidade_ibge == muni_code]),
+      nrow(agrocnefe_st_muni),
+      nrow(agrocnefe_bairro_muni)
     ))
 
     # Perform matching
     result <- match_stbairro_agrocnefe_muni(
       locais_muni = locais_filtered[cod_localidade_ibge == muni_code],
-      agrocnefe_st_muni = agrocnefe_st[id_munic_7 == muni_code],
-      agrocnefe_bairro_muni = agrocnefe_bairro[id_munic_7 == muni_code]
+      agrocnefe_st_muni = agrocnefe_st_muni,
+      agrocnefe_bairro_muni = agrocnefe_bairro_muni
     )
 
     # Log completion
     if (!is.null(result)) {
       message(sprintf(
         "[Batch %d - %d/%d] Completed municipality %s: %d matches",
-        batch_ids,
+        this_batch,
         i,
         length(batch_munis),
         muni_code,
@@ -584,7 +683,7 @@ process_agrocnefe_stbairro_batch <- function(
 
   message(sprintf(
     "[Batch %d] Completed with %d total matches from %d municipalities",
-    batch_ids,
+    this_batch,
     total_matches,
     length(batch_results)
   ))

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -330,11 +330,17 @@ combine_cnefe_state_component <- function(state_results, component, unique_key =
 #' @param ref data.table reference table (must have `id_munic_7`).
 #' @param municipality_batch_assignments data.table with `cod_localidade_ibge`,
 #'   `batch_id`.
+#' @param copy Copy `ref` before the in-place update-join? Defaults to `TRUE` so a
+#'   real target's cached value is never mutated. Callers that already hand in a
+#'   freshly allocated table (e.g. [make_stbairro_batch_groups()] via `rbindlist`)
+#'   pass `FALSE` to avoid a redundant copy of a large reference.
 #' @return `ref` (inner-joined to the assignments) with added `batch_id` and
 #'   `tar_group` columns, intended for `iteration = "group"`.
 #' @export
-make_ref_batch_groups <- function(ref, municipality_batch_assignments) {
-  ref <- data.table::copy(ref)
+make_ref_batch_groups <- function(ref, municipality_batch_assignments, copy = TRUE) {
+  if (copy) {
+    ref <- data.table::copy(ref)
+  }
   ref[
     municipality_batch_assignments,
     batch_id := i.batch_id,
@@ -347,11 +353,17 @@ make_ref_batch_groups <- function(ref, municipality_batch_assignments) {
     # Degenerate case: no reference municipality overlaps the batch assignments,
     # so this reference contributes no matches at all. (Dev mode hits this for
     # Agro CNEFE, whose municipality codes do not intersect the AC/RR polling
-    # municipalities.) `pattern = map()` cannot branch over an empty target, so
-    # emit one placeholder group carrying no real municipality (id_munic_7 = NA).
-    # The match batch then runs once, every per-municipality lookup misses, and
-    # the combined result is the same empty data.table the whole-table path
-    # produced -- equivalence preserved, no crash.
+    # municipalities -- bug #75.) `pattern = map()` cannot branch over an empty
+    # target, so emit one placeholder group carrying no real municipality
+    # (id_munic_7 = NA). The match batch then runs once, every per-municipality
+    # lookup misses, and the combined result is the same empty data.table the
+    # whole-table path produced -- equivalence preserved, no crash. The warning
+    # keeps a genuinely unexpected empty reference from passing silently.
+    warning(
+      "make_ref_batch_groups(): reference has no municipality overlap with the ",
+      "batch assignments; emitting one empty placeholder group (no matches). ",
+      "Expected in dev mode for Agro CNEFE (#75); investigate otherwise."
+    )
     ref <- ref[NA_integer_]
     ref[, batch_id := municipality_batch_assignments$batch_id[1]]
   }
@@ -377,10 +389,16 @@ make_ref_batch_groups <- function(ref, municipality_batch_assignments) {
 #'   `batch_id`/`tar_group`, intended for `iteration = "group"`.
 #' @export
 make_stbairro_batch_groups <- function(ref_st, ref_bairro, municipality_batch_assignments) {
-  st <- data.table::copy(ref_st)[, component := "st"]
-  bairro <- data.table::copy(ref_bairro)[, component := "bairro"]
-  ref <- data.table::rbindlist(list(st, bairro), use.names = TRUE, fill = TRUE)
-  make_ref_batch_groups(ref, municipality_batch_assignments)
+  # rbindlist(idcol=) tags each source with its `component` and returns a fresh
+  # table, so neither input is copied or mutated. The union is already fresh,
+  # hence copy = FALSE below.
+  ref <- data.table::rbindlist(
+    list(st = ref_st, bairro = ref_bairro),
+    use.names = TRUE,
+    fill = TRUE,
+    idcol = "component"
+  )
+  make_ref_batch_groups(ref, municipality_batch_assignments, copy = FALSE)
 }
 
 #' Process INEP string matching in batches
@@ -494,49 +512,56 @@ process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, l
   }
 }
 
-#' Process CNEFE street/neighborhood matching in batches
+#' Process street/neighborhood matching for one batch slice
 #'
-#' `cnefe_stbairro` is a per-batch grouped-stem slice (Option A, issue #68): the
-#' union of the street and neighborhood aggregates for this batch's
-#' municipalities, tagged by `component` and carrying a constant `batch_id`. The
-#' whole national tables never cross to the worker; municipalities are still
-#' taken from `municipality_batch_assignments` so the combined row order is
-#' byte-identical to the pre-reshape pipeline.
+#' Shared engine for the CNEFE and Agro CNEFE street/neighborhood match batches,
+#' which differ only in the per-municipality matcher and the log label. `stbairro`
+#' is a per-batch grouped-stem slice (Option A, issue #68): the union of the
+#' street and neighborhood aggregates for this batch's municipalities, tagged by
+#' `component` and carrying a constant `batch_id`. The whole national tables never
+#' cross to the worker; municipalities are still taken from
+#' `municipality_batch_assignments` so the combined row order is byte-identical to
+#' the pre-reshape pipeline.
 #'
 #' @param municipality_batch_assignments Batch assignments
 #' @param locais_filtered Filtered polling stations
-#' @param cnefe_stbairro Per-batch slice: union of street + neighborhood CNEFE
-#'   aggregates, tagged by `component`
+#' @param stbairro Per-batch slice: union of street + neighborhood aggregates,
+#'   tagged by `component`
+#' @param match_fn Per-municipality matcher called positionally as
+#'   `match_fn(locais_muni, st_muni, bairro_muni)`
+#' @param label Human-readable source label for the log lines (e.g. `"CNEFE"`)
 #' @return Combined match results
 #' @export
-process_cnefe_stbairro_batch <- function(
+process_stbairro_batch <- function(
   municipality_batch_assignments,
   locais_filtered,
-  cnefe_stbairro
+  stbairro,
+  match_fn,
+  label
 ) {
-  this_batch <- cnefe_stbairro$batch_id[1]
+  this_batch <- stbairro$batch_id[1]
   batch_munis <- municipality_batch_assignments[
     batch_id == this_batch
   ]$cod_localidade_ibge
 
-  cnefe_st <- cnefe_stbairro[component == "st"]
-  cnefe_bairro <- cnefe_stbairro[component == "bairro"]
-  data.table::setkey(cnefe_st, id_munic_7)
-  data.table::setkey(cnefe_bairro, id_munic_7)
+  st <- stbairro[component == "st"]
+  bairro <- stbairro[component == "bairro"]
+  data.table::setkey(st, id_munic_7)
+  data.table::setkey(bairro, id_munic_7)
 
-  # Log batch start
   message(sprintf(
-    "[Batch %d] Starting CNEFE street/neighborhood matching for %d municipalities",
+    "[Batch %d] Starting %s street/neighborhood matching for %d municipalities",
     this_batch,
+    label,
     length(batch_munis)
   ))
 
-  # Process all municipalities in this batch with progress tracking
   batch_results <- lapply(seq_along(batch_munis), function(i) {
     muni_code <- batch_munis[i]
 
-    cnefe_st_muni <- cnefe_st[.(muni_code), nomatch = NULL]
-    cnefe_bairro_muni <- cnefe_bairro[.(muni_code), nomatch = NULL]
+    locais_muni <- locais_filtered[cod_localidade_ibge == muni_code]
+    st_muni <- st[.(muni_code), nomatch = NULL]
+    bairro_muni <- bairro[.(muni_code), nomatch = NULL]
 
     message(sprintf(
       "[Batch %d - %d/%d] Processing municipality %s: %d polling stations, %d streets, %d neighborhoods",
@@ -544,19 +569,13 @@ process_cnefe_stbairro_batch <- function(
       i,
       length(batch_munis),
       muni_code,
-      nrow(locais_filtered[cod_localidade_ibge == muni_code]),
-      nrow(cnefe_st_muni),
-      nrow(cnefe_bairro_muni)
+      nrow(locais_muni),
+      nrow(st_muni),
+      nrow(bairro_muni)
     ))
 
-    # Perform matching
-    result <- match_stbairro_cnefe_muni(
-      locais_muni = locais_filtered[cod_localidade_ibge == muni_code],
-      cnefe_st_muni = cnefe_st_muni,
-      cnefe_bairro_muni = cnefe_bairro_muni
-    )
+    result <- match_fn(locais_muni, st_muni, bairro_muni)
 
-    # Log completion
     if (!is.null(result)) {
       message(sprintf(
         "[Batch %d - %d/%d] Completed municipality %s: %d matches",
@@ -571,10 +590,8 @@ process_cnefe_stbairro_batch <- function(
     result
   })
 
-  # Remove NULL results and combine
   batch_results <- batch_results[!sapply(batch_results, is.null)]
 
-  # Log batch completion
   total_matches <- if (length(batch_results) > 0) {
     sum(sapply(batch_results, nrow))
   } else {
@@ -595,13 +612,33 @@ process_cnefe_stbairro_batch <- function(
   }
 }
 
+#' Process CNEFE street/neighborhood matching in batches
+#'
+#' Thin wrapper over [process_stbairro_batch()] with the CNEFE matcher.
+#'
+#' @param municipality_batch_assignments Batch assignments
+#' @param locais_filtered Filtered polling stations
+#' @param cnefe_stbairro Per-batch slice: union of street + neighborhood CNEFE
+#'   aggregates, tagged by `component`
+#' @return Combined match results
+#' @export
+process_cnefe_stbairro_batch <- function(
+  municipality_batch_assignments,
+  locais_filtered,
+  cnefe_stbairro
+) {
+  process_stbairro_batch(
+    municipality_batch_assignments,
+    locais_filtered,
+    cnefe_stbairro,
+    match_fn = match_stbairro_cnefe_muni,
+    label = "CNEFE"
+  )
+}
+
 #' Process Agro CNEFE street/neighborhood matching in batches
 #'
-#' `agrocnefe_stbairro` is a per-batch grouped-stem slice (Option A, issue #68):
-#' the union of the street and neighborhood aggregates for this batch's
-#' municipalities, tagged by `component` and carrying a constant `batch_id`.
-#' Municipalities are still taken from `municipality_batch_assignments` so the
-#' combined row order is byte-identical to the pre-reshape pipeline.
+#' Thin wrapper over [process_stbairro_batch()] with the Agro CNEFE matcher.
 #'
 #' @param municipality_batch_assignments Batch assignments
 #' @param locais_filtered Filtered polling stations
@@ -614,85 +651,13 @@ process_agrocnefe_stbairro_batch <- function(
   locais_filtered,
   agrocnefe_stbairro
 ) {
-  this_batch <- agrocnefe_stbairro$batch_id[1]
-  batch_munis <- municipality_batch_assignments[
-    batch_id == this_batch
-  ]$cod_localidade_ibge
-
-  agrocnefe_st <- agrocnefe_stbairro[component == "st"]
-  agrocnefe_bairro <- agrocnefe_stbairro[component == "bairro"]
-  data.table::setkey(agrocnefe_st, id_munic_7)
-  data.table::setkey(agrocnefe_bairro, id_munic_7)
-
-  # Log batch start
-  message(sprintf(
-    "[Batch %d] Starting Agro CNEFE street/neighborhood matching for %d municipalities",
-    this_batch,
-    length(batch_munis)
-  ))
-
-  # Process all municipalities in this batch with progress tracking
-  batch_results <- lapply(seq_along(batch_munis), function(i) {
-    muni_code <- batch_munis[i]
-
-    agrocnefe_st_muni <- agrocnefe_st[.(muni_code), nomatch = NULL]
-    agrocnefe_bairro_muni <- agrocnefe_bairro[.(muni_code), nomatch = NULL]
-
-    message(sprintf(
-      "[Batch %d - %d/%d] Processing municipality %s: %d polling stations, %d streets, %d neighborhoods",
-      this_batch,
-      i,
-      length(batch_munis),
-      muni_code,
-      nrow(locais_filtered[cod_localidade_ibge == muni_code]),
-      nrow(agrocnefe_st_muni),
-      nrow(agrocnefe_bairro_muni)
-    ))
-
-    # Perform matching
-    result <- match_stbairro_agrocnefe_muni(
-      locais_muni = locais_filtered[cod_localidade_ibge == muni_code],
-      agrocnefe_st_muni = agrocnefe_st_muni,
-      agrocnefe_bairro_muni = agrocnefe_bairro_muni
-    )
-
-    # Log completion
-    if (!is.null(result)) {
-      message(sprintf(
-        "[Batch %d - %d/%d] Completed municipality %s: %d matches",
-        this_batch,
-        i,
-        length(batch_munis),
-        muni_code,
-        nrow(result)
-      ))
-    }
-
-    result
-  })
-
-  # Remove NULL results and combine
-  batch_results <- batch_results[!sapply(batch_results, is.null)]
-
-  # Log batch completion
-  total_matches <- if (length(batch_results) > 0) {
-    sum(sapply(batch_results, nrow))
-  } else {
-    0
-  }
-
-  message(sprintf(
-    "[Batch %d] Completed with %d total matches from %d municipalities",
-    this_batch,
-    total_matches,
-    length(batch_results)
-  ))
-
-  if (length(batch_results) > 0) {
-    rbindlist(batch_results, use.names = TRUE, fill = TRUE)
-  } else {
-    data.table()
-  }
+  process_stbairro_batch(
+    municipality_batch_assignments,
+    locais_filtered,
+    agrocnefe_stbairro,
+    match_fn = match_stbairro_agrocnefe_muni,
+    label = "Agro CNEFE"
+  )
 }
 # ===== PARALLEL PROCESSING =====
 

--- a/_targets.R
+++ b/_targets.R
@@ -684,20 +684,92 @@ list(
     command = unique(municipality_batch_assignments$batch_id)
   ),
 
+  # ---- Reference slices (Option A, issue #68) --------------------------------
+  # One grouped stem per CNEFE-family match target: each reference table is
+  # inner-joined to its batch_id and split into per-batch groups so the match
+  # targets can `pattern = map()` over the groups with `retrieval = "main"` and
+  # receive only their batch's slice (megabytes) instead of the whole national
+  # table (hundreds of megabytes). Built on the main process and held in
+  # persistent memory so the stem is not re-read for every branch dispatch
+  # (spike #66 settings). The stbairro stems union the street + neighborhood
+  # aggregates into one table (tagged by `component`) so the pair can never fall
+  # out of group alignment.
+  # inep_data is ~61 MB in production (measured, issue #68 / spec D3), so it clears
+  # the "non-trivially large" bar and is sliced like the CNEFE-family references.
+  tar_target(
+    name = inep_grouped,
+    command = make_ref_batch_groups(inep_data, municipality_batch_assignments),
+    iteration = "group",
+    deployment = "main",
+    memory = "persistent",
+    format = "qs"
+  ),
+  tar_target(
+    name = schools_cnefe10_grouped,
+    command = make_ref_batch_groups(schools_cnefe10, municipality_batch_assignments),
+    iteration = "group",
+    deployment = "main",
+    memory = "persistent",
+    format = "qs"
+  ),
+  tar_target(
+    name = schools_cnefe22_grouped,
+    command = make_ref_batch_groups(schools_cnefe22, municipality_batch_assignments),
+    iteration = "group",
+    deployment = "main",
+    memory = "persistent",
+    format = "qs"
+  ),
+  tar_target(
+    name = cnefe10_stbairro_grouped,
+    command = make_stbairro_batch_groups(
+      cnefe10_st,
+      cnefe10_bairro,
+      municipality_batch_assignments
+    ),
+    iteration = "group",
+    deployment = "main",
+    memory = "persistent",
+    format = "qs"
+  ),
+  tar_target(
+    name = cnefe22_stbairro_grouped,
+    command = make_stbairro_batch_groups(
+      cnefe22_st,
+      cnefe22_bairro,
+      municipality_batch_assignments
+    ),
+    iteration = "group",
+    deployment = "main",
+    memory = "persistent",
+    format = "qs"
+  ),
+  tar_target(
+    name = agrocnefe_stbairro_grouped,
+    command = make_stbairro_batch_groups(
+      agrocnefe_st,
+      agrocnefe_bairro,
+      municipality_batch_assignments
+    ),
+    iteration = "group",
+    deployment = "main",
+    memory = "persistent",
+    format = "qs"
+  ),
+
   # INEP string matching - process municipalities in batches
   tar_target(
     name = inep_string_match_batch,
     command = process_inep_batch(
-      batch_ids = batch_ids,
       municipality_batch_assignments = municipality_batch_assignments,
       locais_filtered = locais_filtered,
-      inep_data = inep_data
+      inep_data = inep_grouped
     ),
-    pattern = map(batch_ids),
+    pattern = map(inep_grouped),
     iteration = "list",
     deployment = "worker",
     storage = "worker",
-    retrieval = "worker",
+    retrieval = "main",
     resources = tar_resources(
       crew = tar_resources_crew(controller = "standard")
     )
@@ -711,18 +783,17 @@ list(
   tar_target(
     name = schools_cnefe10_match_batch,
     command = process_schools_cnefe_batch(
-      batch_ids = batch_ids,
       municipality_batch_assignments = municipality_batch_assignments,
       locais_filtered = locais_filtered,
-      schools_cnefe = schools_cnefe10
+      schools_cnefe = schools_cnefe10_grouped
     ),
-    pattern = map(batch_ids),
+    pattern = map(schools_cnefe10_grouped),
     iteration = "list",
     deployment = "worker",
     storage = "worker",
-    retrieval = "worker",
+    retrieval = "main",
     resources = tar_resources(
-      crew = tar_resources_crew(controller = "memory_limited")
+      crew = tar_resources_crew(controller = "standard")
     )
   ),
   tar_target(
@@ -735,18 +806,17 @@ list(
   tar_target(
     name = schools_cnefe22_match_batch,
     command = process_schools_cnefe_batch(
-      batch_ids = batch_ids,
       municipality_batch_assignments = municipality_batch_assignments,
       locais_filtered = locais_filtered,
-      schools_cnefe = schools_cnefe22
+      schools_cnefe = schools_cnefe22_grouped
     ),
-    pattern = map(batch_ids),
+    pattern = map(schools_cnefe22_grouped),
     iteration = "list",
     deployment = "worker",
     storage = "worker",
-    retrieval = "worker",
+    retrieval = "main",
     resources = tar_resources(
-      crew = tar_resources_crew(controller = "memory_limited")
+      crew = tar_resources_crew(controller = "standard")
     )
   ),
   tar_target(
@@ -758,21 +828,28 @@ list(
     ),
     deployment = "main"
   ),
-  # CNEFE 2010 street/neighborhood matching with batched dynamic branching
+  # CNEFE 2010 street/neighborhood matching with batched dynamic branching.
+  # Controller stays `memory_limited` (8 workers), NOT promoted to `standard`
+  # (issue #68, D2, data-driven decision). Slicing removes the ~350 MB whole-
+  # reference residency per worker, but the street/neighborhood matcher's peak is
+  # the per-municipality distance matrix -- min(10000, n_locais) x n_ref_streets x
+  # 8 bytes -- which reaches multiple GB for the largest cities (Sao Paulo has
+  # tens of thousands of unique streets) and is unchanged by this reshape. At 28
+  # workers that risks exceeding the 50 GB machine; at 8 workers it is safe and
+  # still benefits from the slimmer reference. See the measurements recorded on
+  # the issue.
   tar_target(
     name = cnefe10_stbairro_match_batch,
     command = process_cnefe_stbairro_batch(
-      batch_ids = batch_ids,
       municipality_batch_assignments = municipality_batch_assignments,
       locais_filtered = locais_filtered,
-      cnefe_st = cnefe10_st,
-      cnefe_bairro = cnefe10_bairro
+      cnefe_stbairro = cnefe10_stbairro_grouped
     ),
-    pattern = map(batch_ids),
+    pattern = map(cnefe10_stbairro_grouped),
     iteration = "list",
     deployment = "worker",
     storage = "worker",
-    retrieval = "worker",
+    retrieval = "main",
     resources = tar_resources(
       crew = tar_resources_crew(controller = "memory_limited")
     )
@@ -783,21 +860,21 @@ list(
     storage = "worker",
     retrieval = "worker"
   ),
-  # CNEFE 2022 street/neighborhood matching with batched dynamic branching
+  # CNEFE 2022 street/neighborhood matching with batched dynamic branching.
+  # Controller stays `memory_limited` for the same reason as the 2010 target
+  # above (issue #68, D2): multi-GB per-branch distance matrix for large cities.
   tar_target(
     name = cnefe22_stbairro_match_batch,
     command = process_cnefe_stbairro_batch(
-      batch_ids = batch_ids,
       municipality_batch_assignments = municipality_batch_assignments,
       locais_filtered = locais_filtered,
-      cnefe_st = cnefe22_st,
-      cnefe_bairro = cnefe22_bairro
+      cnefe_stbairro = cnefe22_stbairro_grouped
     ),
-    pattern = map(batch_ids),
+    pattern = map(cnefe22_stbairro_grouped),
     iteration = "list",
     deployment = "worker",
     storage = "worker",
-    retrieval = "worker",
+    retrieval = "main",
     resources = tar_resources(
       crew = tar_resources_crew(controller = "memory_limited")
     )
@@ -808,21 +885,25 @@ list(
     storage = "worker",
     retrieval = "worker"
   ),
-  # Agro CNEFE street/neighborhood matching with batched dynamic branching
+  # Agro CNEFE street/neighborhood matching with batched dynamic branching.
+  # Controller stays `memory_limited` (issue #68, D2): this is a street/
+  # neighborhood matcher of the same class as the CNEFE stbairro targets, so once
+  # its code-scheme bug (#75) is fixed and it matches against the full rural
+  # reference, its per-branch peak is the same multi-GB matrix. Keeping it here
+  # avoids a latent OOM when #75 lands. (It currently produces an empty match --
+  # see #75 -- so it is trivially safe today either way.)
   tar_target(
     name = agrocnefe_stbairro_match_batch,
     command = process_agrocnefe_stbairro_batch(
-      batch_ids = batch_ids,
       municipality_batch_assignments = municipality_batch_assignments,
       locais_filtered = locais_filtered,
-      agrocnefe_st = agrocnefe_st,
-      agrocnefe_bairro = agrocnefe_bairro
+      agrocnefe_stbairro = agrocnefe_stbairro_grouped
     ),
-    pattern = map(batch_ids),
+    pattern = map(agrocnefe_stbairro_grouped),
     iteration = "list",
     deployment = "worker",
     storage = "worker",
-    retrieval = "worker",
+    retrieval = "main",
     resources = tar_resources(
       crew = tar_resources_crew(controller = "memory_limited")
     )


### PR DESCRIPTION
Closes #68.

## What this PR is for (plain language)

When the pipeline matches polling stations to reference addresses, it splits the
work into ~372 parallel tasks, each handling about 15 municipalities. Today each
of those tasks receives a **complete national reference table** (street and
neighbourhood coordinates, school lists) and then throws away everything except
its own municipalities. That wastes a lot of memory — every worker holds hundreds
of megabytes it never uses, which is a big part of why the pipeline needs a 50 GB+
machine.

This PR hands each task **only its own slice** of every reference table. The
result is the same, byte for byte; it just uses far less memory, and lets the
lighter matching tasks run on the wide 28-worker pool instead of the memory-
restricted 8-worker pool.

## How it works

Uses the grouped-stem mechanism proven by the #66 spike (Option A). For each
reference table, a new target joins every row to its batch number (from
`municipality_batch_assignments`, the existing source of truth) and splits the
table into per-batch groups. The match targets map over those groups with
`retrieval = "main"`, so the main process ships only the relevant slice to each
worker. Per-worker reference residency drops from hundreds of MB to a few MB.

Street and neighbourhood aggregates are unioned into a single grouped stem
(tagged by a `component` column) so the pair can never fall out of branch
alignment.

## Scope and decisions (spec `docs/specs/2026-07-partition-reference-data-spec.md`)

- **Sliced:** `schools_cnefe10`, `schools_cnefe22`, `cnefe10_stbairro`,
  `cnefe22_stbairro`, `agrocnefe_stbairro`, and — new — `inep`. The production
  INEP catalog measured **61 MB**, clearing the D3 "non-trivially large" bar, so
  it joins the mechanism.
- **Controller promotion (D2):** the name-only matchers (schools, inep) move to
  the 28-worker `standard` pool. The three street/neighbourhood (`stbairro`)
  matchers stay on the 8-worker `memory_limited` pool: their per-branch distance
  matrix reaches multiple GB for the largest cities and is unchanged by slicing,
  so 28-wide would risk the 50 GB machine. Full measurements are recorded on #68.

## Verification

- Dev-mode (AC/RR) equivalence via `tests/integration/equivalence_check.R`:
  **15/15 compared targets byte-identical to the master baseline, 0 diffs** (six
  reference aggregates, all seven match outputs, `model_data`, `geocoded_locais`),
  re-confirmed after the /simplify cleanup.
- Fast unit tests pass (279).
- /simplify applied (dedup the two `stbairro` batch functions, drop redundant
  ~350 MB copies). Codex review: no correctness issues.

## Follow-ups filed

- #75 — Agro CNEFE builds `id_munic_7` with leading-zero loss, giving zero code
  overlap in dev mode (pre-existing; this PR preserves the empty behaviour via an
  empty-reference guard rather than fixing it).
- #76 — key `locais_filtered` per branch to remove repeated full scans
  (pre-existing hot path, out of scope here).

## Not done here

Controller promotion and S3 are not exercised by dev mode, so the first
production run after merge should be diffed against the shipped
`geocoded_polling_stations.csv.gz` / `panel_ids.csv.gz` as the production backstop
(spec D7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)