### PR TITLE
Fix Agro CNEFE id_munic_7 leading-zero loss (#75)

### DIFF
--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -305,9 +305,18 @@ clean_tsegeocoded_locais <- function(tse_files, muni_ids, locais) {
 }
 
 clean_agro_cnefe <- function(agro_cnefe_files, muni_ids) {
-  # Read and combine all agro census files
+  # Read and combine all agro census files.
+  # COD_UF/COD_MUNICIPIO are zero-padded numeric strings in the source files
+  # (e.g. "12" + "00401"). Read them as character so fread does not infer them
+  # as integers and strip the leading zeros; the padding is what makes
+  # paste0(cod_uf, cod_municipio) a valid 7-digit IBGE code (#75).
   agro_list <- lapply(agro_cnefe_files, function(file) {
-    fread(file, encoding = "UTF-8", sep = ";")
+    fread(
+      file,
+      encoding = "UTF-8",
+      sep = ";",
+      colClasses = list(character = c("COD_UF", "COD_MUNICIPIO"))
+    )
   })
   agro_cnefe <- rbindlist(agro_list, fill = TRUE)
 
@@ -325,6 +334,19 @@ clean_agro_cnefe <- function(agro_cnefe_files, muni_ids) {
 
   # Create id_munic_7 from cod_uf and cod_municipio BEFORE standardization
   agro_cnefe[, id_munic_7 := as.numeric(paste0(cod_uf, cod_municipio))]
+
+  # Fail loud if the municipality key does not line up with the polling-station
+  # municipalities. Zero overlap means the leading-zero padding was lost on read
+  # (the #75 regression) and every downstream agrocnefe_stbairro lookup would
+  # silently match nothing.
+  if (!any(unique(agro_cnefe$id_munic_7) %in% muni_ids$id_munic_7)) {
+    stop(
+      "clean_agro_cnefe(): id_munic_7 has zero overlap with muni_ids$id_munic_7. ",
+      "COD_UF/COD_MUNICIPIO likely lost their leading zeros on read (see #75). ",
+      "Sample agro id_munic_7: ",
+      paste(utils::head(sort(unique(agro_cnefe$id_munic_7))), collapse = ", ")
+    )
+  }
 
   # Now standardize column names
   standardize_column_names(agro_cnefe, inplace = TRUE)

--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -339,7 +339,7 @@ clean_agro_cnefe <- function(agro_cnefe_files, muni_ids) {
   # municipalities. Zero overlap means the leading-zero padding was lost on read
   # (the #75 regression) and every downstream agrocnefe_stbairro lookup would
   # silently match nothing.
-  if (!any(unique(agro_cnefe$id_munic_7) %in% muni_ids$id_munic_7)) {
+  if (!any(agro_cnefe$id_munic_7 %in% muni_ids$id_munic_7)) {
     stop(
       "clean_agro_cnefe(): id_munic_7 has zero overlap with muni_ids$id_munic_7. ",
       "COD_UF/COD_MUNICIPIO likely lost their leading zeros on read (see #75). ",

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -351,18 +351,18 @@ make_ref_batch_groups <- function(ref, municipality_batch_assignments, copy = TR
   ref <- ref[!is.na(batch_id)]
   if (nrow(ref) == 0L) {
     # Degenerate case: no reference municipality overlaps the batch assignments,
-    # so this reference contributes no matches at all. (Dev mode hits this for
-    # Agro CNEFE, whose municipality codes do not intersect the AC/RR polling
-    # municipalities -- bug #75.) `pattern = map()` cannot branch over an empty
-    # target, so emit one placeholder group carrying no real municipality
-    # (id_munic_7 = NA). The match batch then runs once, every per-municipality
-    # lookup misses, and the combined result is the same empty data.table the
-    # whole-table path produced -- equivalence preserved, no crash. The warning
-    # keeps a genuinely unexpected empty reference from passing silently.
+    # so this reference contributes no matches at all. `pattern = map()` cannot
+    # branch over an empty target, so emit one placeholder group carrying no real
+    # municipality (id_munic_7 = NA). The match batch then runs once, every
+    # per-municipality lookup misses, and the combined result is the same empty
+    # data.table the whole-table path produced -- no crash. This is not expected
+    # for any reference in normal operation (Agro CNEFE used to hit it in dev via
+    # bug #75, now fixed), so the warning keeps a genuinely empty reference from
+    # passing silently.
     warning(
       "make_ref_batch_groups(): reference has no municipality overlap with the ",
       "batch assignments; emitting one empty placeholder group (no matches). ",
-      "Expected in dev mode for Agro CNEFE (#75); investigate otherwise."
+      "Not expected in normal operation -- investigate."
     )
     ref <- ref[NA_integer_]
     ref[, batch_id := municipality_batch_assignments$batch_id[1]]


### PR DESCRIPTION
## Purpose

The 2017 Agro CNEFE dataset is one source we use to attach coordinates to
polling stations by matching street and neighborhood names within each
municipality. This change fixes a bug that made that entire matching step
silently produce nothing — it was doing work but never finding a single
match, in the real production run as well as in the small dev-mode test run.
After this fix, the Agro CNEFE step actually contributes matches again.

## The bug (#75)

`clean_agro_cnefe()` builds each municipality's 7-digit IBGE code by gluing
together the state code and the within-state municipality code:
`paste0(cod_uf, cod_municipio)`. In the source files the municipality code is
stored zero-padded (for example `"00401"`), so gluing gives the correct
`"1200401"`. But `fread` guessed that column was an integer and threw away the
leading zeros (`"00401"` became `401`), so the code came out as `"12401"` — a
malformed short code. Those malformed codes have **zero overlap** with the
municipality codes used everywhere else in the pipeline, so every
per-municipality lookup in the Agro CNEFE matching step found nothing and the
match output was empty.

This was not specific to dev mode. `fread`'s type guessing is the same in
production, so the production Agro CNEFE match layer was also empty and its
CPU time was wasted.

## The fix

- Read the two code columns (`COD_UF`, `COD_MUNICIPIO`) as text instead of
  letting `fread` guess, so the zero-padding in the file is preserved and the
  glued 7-digit code is correct.
- Add a fail-loud assertion: if the resulting codes have zero overlap with the
  polling-station municipality codes, stop with a clear error instead of
  silently producing an empty match. This is exactly the failure mode #75 hid,
  so now it can never pass silently again.
- Update a stale comment in `make_ref_batch_groups()` (added while partitioning
  reference tables in #68) that documented an empty Agro CNEFE reference as
  *expected* in dev mode. With this fix it is no longer expected, so the guard
  now reads as purely defensive.

## Verification

Ran `clean_agro_cnefe()` against the real Acre and Roraima files: all 37
municipality codes now come out as valid 7-digit codes, all 37 join the
municipality reference table (previously 0 of them did), and a sample
municipality that returned 0 streets before now returns 121. The fast unit
test suite passes (279 passed, 0 failed).

## Note: this is an intended behavior change

`agrocnefe_stbairro_match` was empty in dev mode and is now non-empty, so the
local equivalence-check snapshot (a refactoring-safety tool, not a spec test)
will correctly flag a difference and should be re-snapshotted. This is the
behavior change #75 called out as out of scope for the pure reshape in #68.

## Follow-up

Filed #78 (low priority): the same code-building idiom now lives in two cleaners
with two different zero-pad guards; a shared `make_id_munic_7()` helper would
prevent a future copy from reintroducing this bug.

Closes #75.

🤖 Generated with [Claude Code](https://claude.com/claude-code)