### PR TITLE
Key locais_filtered per batch for keyed muni lookups (#76)

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -421,11 +421,12 @@ process_inep_batch <- function(municipality_batch_assignments, locais_filtered, 
   ]$cod_localidade_ibge
 
   data.table::setkey(inep_data, id_munic_7)
+  data.table::setkey(locais_filtered, cod_localidade_ibge)
 
   # Process all municipalities in this batch
   batch_results <- lapply(batch_munis, function(muni_code) {
     match_inep_muni(
-      locais_muni = locais_filtered[cod_localidade_ibge == muni_code],
+      locais_muni = locais_filtered[.(muni_code), nomatch = NULL],
       inep_muni = inep_data[.(muni_code), nomatch = NULL]
     )
   })
@@ -460,10 +461,11 @@ process_schools_cnefe_batch <- function(municipality_batch_assignments, locais_f
   ]$cod_localidade_ibge
 
   data.table::setkey(schools_cnefe, id_munic_7)
+  data.table::setkey(locais_filtered, cod_localidade_ibge)
 
   batch_results <- lapply(batch_munis, function(muni_code) {
     match_schools_cnefe_muni(
-      locais_muni = locais_filtered[cod_localidade_ibge == muni_code],
+      locais_muni = locais_filtered[.(muni_code), nomatch = NULL],
       schools_cnefe_muni = schools_cnefe[.(muni_code), nomatch = NULL]
     )
   })
@@ -491,6 +493,8 @@ process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, l
     batch_id == batch_ids
   ]$cod_localidade_ibge
 
+  data.table::setkey(locais_filtered, cod_localidade_ibge)
+
   # Collect-and-stop (cleanup phase 3, finding C5): a NULL result (no polling
   # stations or no geocoding hits) is a legitimate empty case and is filtered;
   # a municipality that errors is surfaced at batch end, never silently dropped.
@@ -498,7 +502,7 @@ process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, l
     batch_munis,
     function(muni_code) {
       match_geocodebr_muni(
-        locais_muni = locais_filtered[cod_localidade_ibge == muni_code],
+        locais_muni = locais_filtered[.(muni_code), nomatch = NULL],
         muni_ids = muni_ids[id_munic_7 == muni_code]
       )
     },
@@ -548,6 +552,7 @@ process_stbairro_batch <- function(
   bairro <- stbairro[component == "bairro"]
   data.table::setkey(st, id_munic_7)
   data.table::setkey(bairro, id_munic_7)
+  data.table::setkey(locais_filtered, cod_localidade_ibge)
 
   message(sprintf(
     "[Batch %d] Starting %s street/neighborhood matching for %d municipalities",
@@ -559,7 +564,7 @@ process_stbairro_batch <- function(
   batch_results <- lapply(seq_along(batch_munis), function(i) {
     muni_code <- batch_munis[i]
 
-    locais_muni <- locais_filtered[cod_localidade_ibge == muni_code]
+    locais_muni <- locais_filtered[.(muni_code), nomatch = NULL]
     st_muni <- st[.(muni_code), nomatch = NULL]
     bairro_muni <- bairro[.(muni_code), nomatch = NULL]
 


### PR DESCRIPTION
## Purpose

Every per-municipality matching loop was scanning the entire national polling-station table (`locais_filtered`, ~940k rows / ~167 MB) from top to bottom just to pull out the handful of rows for one municipality. It did this once per municipality, in four different matching functions, across hundreds of batches — a large amount of repeated, wasted scanning. This change makes each function sort that table by municipality code once up front, so every subsequent per-municipality lookup is a fast index lookup instead of a full scan. The results are unchanged; only the speed of finding rows changes.

Closes #76.

## What changed

In the four per-municipality match batch functions in `R/utilities.R` (`process_inep_batch`, `process_schools_cnefe_batch`, `process_geocodebr_batch`, and the shared `process_stbairro_batch`), the unkeyed vector scan

```r
locais_filtered[cod_localidade_ibge == muni_code]
```

is replaced by a keyed binary-search lookup

```r
data.table::setkey(locais_filtered, cod_localidade_ibge)  # once, at the top
locais_filtered[.(muni_code), nomatch = NULL]             # per municipality
```

Each function keys its own freshly deserialized `locais_filtered` copy inside the worker, so the in-place `setkey` has no cross-worker effect. This mirrors how the #68 reshape already keys the *reference* slices; `locais_filtered` was the one table still being vector-scanned.

## Why output is unchanged

`setkey` uses a stable sort, so rows within a single municipality keep their original relative order. The keyed lookup therefore returns the same rows in the same order as the vector scan, and every downstream match is identical.

## Verification

- **Dev-mode equivalence harness** (`tests/integration/equivalence_check.R`): snapshot on `master`, rebuild + compare on this branch. **All 15 compared targets are byte-identical** (`identical()` strictness) — the six reference aggregates, all seven match outputs (including `geocodebr_match`), `model_data`, and `geocoded_locais`.
- **Fast unit tests** (`Rscript tests/testthat.R`): PASS 279, FAIL 0.
- `/simplify` review: no findings (diff is nine mechanical lines matching the issue spec).
- Codex review vs `master`: no correctness issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S4oi1wqC8mCDaFmBM7SHhW