### PR TITLE
Extract shared make_id_munic_7() helper for CNEFE cleaners (#78)

### DIFF
--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -304,6 +304,28 @@ clean_tsegeocoded_locais <- function(tse_files, muni_ids, locais) {
   locs
 }
 
+# Build the 7-digit IBGE municipality key from separate UF + municipality codes.
+# cod_uf is the 2-digit state code (11-53, never zero-padded); cod_municipio is
+# the within-state code that MUST be zero-padded to width 5 before pasting, or
+# codes like "12" + "401" collapse to 12401 instead of 1200401 and share zero
+# overlap with the polling-station municipalities (the #75 regression). The
+# padding is done here so every caller gets the guard for free, and the 7-digit
+# assertion fails loud if a caller fed codes that already lost their leading
+# zeros upstream.
+make_id_munic_7 <- function(cod_uf, cod_municipio) {
+  cod_municipio <- str_pad(cod_municipio, width = 5, side = "left", pad = "0")
+  id_munic_7 <- as.numeric(paste0(cod_uf, cod_municipio))
+  if (any(id_munic_7 < 1e6 | id_munic_7 >= 1e7, na.rm = TRUE)) {
+    stop(
+      "make_id_munic_7(): produced non-7-digit municipality codes. ",
+      "cod_uf/cod_municipio likely lost their leading zeros upstream (see #75). ",
+      "Sample id_munic_7: ",
+      paste(utils::head(sort(unique(id_munic_7))), collapse = ", ")
+    )
+  }
+  id_munic_7
+}
+
 clean_agro_cnefe <- function(agro_cnefe_files, muni_ids) {
   # Read and combine all agro census files.
   # COD_UF/COD_MUNICIPIO are zero-padded numeric strings in the source files
@@ -333,7 +355,7 @@ clean_agro_cnefe <- function(agro_cnefe_files, muni_ids) {
   ]
 
   # Create id_munic_7 from cod_uf and cod_municipio BEFORE standardization
-  agro_cnefe[, id_munic_7 := as.numeric(paste0(cod_uf, cod_municipio))]
+  agro_cnefe[, id_munic_7 := make_id_munic_7(cod_uf, cod_municipio)]
 
   # Fail loud if the municipality key does not line up with the polling-station
   # municipalities. Zero overlap means the leading-zero padding was lost on read
@@ -803,8 +825,9 @@ clean_cnefe10 <- function(cnefe_file, muni_ids, tract_centroids, extract_schools
     cnefe_chunk[dsc_estabelecimento == "", dsc_estabelecimento := NA]
     cnefe_chunk[, dsc_estabelecimento := str_squish(dsc_estabelecimento)]
 
-    # Add municipality code
-    cnefe_chunk[, id_munic_7 := as.numeric(paste0(cod_uf, cod_municipio))]
+    # Add municipality code (cod_municipio was already padded above for setor_code;
+    # make_id_munic_7 re-pads idempotently and asserts the 7-digit invariant)
+    cnefe_chunk[, id_munic_7 := make_id_munic_7(cod_uf, cod_municipio)]
 
     # Keep only essential columns early
     essential_cols <- c(

--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -358,13 +358,15 @@ clean_agro_cnefe <- function(agro_cnefe_files, muni_ids) {
   agro_cnefe[, id_munic_7 := make_id_munic_7(cod_uf, cod_municipio)]
 
   # Fail loud if the municipality key does not line up with the polling-station
-  # municipalities. Zero overlap means the leading-zero padding was lost on read
-  # (the #75 regression) and every downstream agrocnefe_stbairro lookup would
-  # silently match nothing.
+  # municipalities. make_id_munic_7() already guarantees each code is structurally
+  # 7-digit; this is the stronger semantic check that the codes are real IBGE
+  # municipalities. Zero overlap points to a schema/vintage mismatch in the agro
+  # source, and every downstream agrocnefe_stbairro lookup would silently match
+  # nothing.
   if (!any(agro_cnefe$id_munic_7 %in% muni_ids$id_munic_7)) {
     stop(
       "clean_agro_cnefe(): id_munic_7 has zero overlap with muni_ids$id_munic_7. ",
-      "COD_UF/COD_MUNICIPIO likely lost their leading zeros on read (see #75). ",
+      "The agro COD_UF/COD_MUNICIPIO codes do not match any known municipality. ",
       "Sample agro id_munic_7: ",
       paste(utils::head(sort(unique(agro_cnefe$id_munic_7))), collapse = ", ")
     )

--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -311,14 +311,16 @@ clean_tsegeocoded_locais <- function(tse_files, muni_ids, locais) {
 # overlap with the polling-station municipalities (the #75 regression). The
 # padding is done here so every caller gets the guard for free, and the 7-digit
 # assertion fails loud if a caller fed codes that already lost their leading
-# zeros upstream.
+# zeros upstream. Missing/non-numeric codes coerce to NA; those are rejected too,
+# since an NA municipality key silently sails through the muni_ids join with
+# empty geography rather than matching anything.
 make_id_munic_7 <- function(cod_uf, cod_municipio) {
   cod_municipio <- str_pad(cod_municipio, width = 5, side = "left", pad = "0")
   id_munic_7 <- as.numeric(paste0(cod_uf, cod_municipio))
-  if (any(id_munic_7 < 1e6 | id_munic_7 >= 1e7, na.rm = TRUE)) {
+  if (any(is.na(id_munic_7) | id_munic_7 < 1e6 | id_munic_7 >= 1e7)) {
     stop(
-      "make_id_munic_7(): produced non-7-digit municipality codes. ",
-      "cod_uf/cod_municipio likely lost their leading zeros upstream (see #75). ",
+      "make_id_munic_7(): produced invalid (NA or non-7-digit) municipality codes. ",
+      "cod_uf/cod_municipio were missing or lost their leading zeros upstream (see #75). ",
       "Sample id_munic_7: ",
       paste(utils::head(sort(unique(id_munic_7))), collapse = ", ")
     )

--- a/tests/testthat/test-make_id_munic_7.R
+++ b/tests/testthat/test-make_id_munic_7.R
@@ -20,6 +20,16 @@ test_that("make_id_munic_7 stops when a code is not 7 digits", {
   # A cod_uf that lost its leading structure yields a short code: fail loud.
   expect_error(
     make_id_munic_7("1", "00401"),
-    "non-7-digit municipality codes"
+    "invalid \\(NA or non-7-digit\\) municipality codes"
+  )
+})
+
+test_that("make_id_munic_7 stops on a missing code rather than returning NA", {
+  # A missing municipality key would silently sail through the muni_ids join
+  # with empty geography; reject it at construction instead.
+  # Coercing "NA00401" to numeric warns before the stop(); the stop is the point.
+  expect_error(
+    suppressWarnings(make_id_munic_7(c("12", NA), c("00401", "00401"))),
+    "invalid \\(NA or non-7-digit\\) municipality codes"
   )
 })

--- a/tests/testthat/test-make_id_munic_7.R
+++ b/tests/testthat/test-make_id_munic_7.R
@@ -4,9 +4,8 @@
 ## cod_uf, and the result is a 7-digit IBGE code. A caller that lost the padding
 ## upstream (the #75 regression) must fail loud, not produce short codes.
 
-test_that("make_id_munic_7 zero-pads cod_municipio to width 5 before pasting", {
-  # "12" + "00401" is the padded form; the numeric form 401 must pad the same way.
-  expect_equal(make_id_munic_7("12", "00401"), 1200401)
+test_that("make_id_munic_7 zero-pads a numeric cod_municipio to width 5", {
+  # A numeric 401 (leading zeros already stripped) must pad back to "00401".
   expect_equal(make_id_munic_7("12", 401), 1200401)
 })
 

--- a/tests/testthat/test-make_id_munic_7.R
+++ b/tests/testthat/test-make_id_munic_7.R
@@ -1,0 +1,26 @@
+## Spec test for make_id_munic_7() (R/data_cleaning.R), the shared helper that
+## unifies the divergent leading-zero guards in the CNEFE cleaners (#78). The
+## invariant: cod_municipio is zero-padded to width 5, pasted onto the 2-digit
+## cod_uf, and the result is a 7-digit IBGE code. A caller that lost the padding
+## upstream (the #75 regression) must fail loud, not produce short codes.
+
+test_that("make_id_munic_7 zero-pads cod_municipio to width 5 before pasting", {
+  # "12" + "00401" is the padded form; the numeric form 401 must pad the same way.
+  expect_equal(make_id_munic_7("12", "00401"), 1200401)
+  expect_equal(make_id_munic_7("12", 401), 1200401)
+})
+
+test_that("make_id_munic_7 is vectorized over multiple municipalities", {
+  expect_equal(
+    make_id_munic_7(c("12", "35"), c("00401", "50308")),
+    c(1200401, 3550308)
+  )
+})
+
+test_that("make_id_munic_7 stops when a code is not 7 digits", {
+  # A cod_uf that lost its leading structure yields a short code: fail loud.
+  expect_error(
+    make_id_munic_7("1", "00401"),
+    "non-7-digit municipality codes"
+  )
+})


### PR DESCRIPTION
## Purpose

Two of the CNEFE data cleaners were each building Brazil's 7-digit municipality
identifier (`id_munic_7`) from separate state and municipality code columns, and
each one guarded against a known data-corruption problem in its own different
way. This made it easy for a future third cleaner to copy the code without the
guard and silently reintroduce a bug where municipality codes lose their leading
zeros and match nothing downstream (the problem originally fixed in #75). This
change puts that construction and its safety check in one shared place so it
can't be gotten wrong at a call site.

Closes #78.

## What changed

- **New helper `make_id_munic_7(cod_uf, cod_municipio)`** in `R/data_cleaning.R`.
  It zero-pads the municipality code to width 5, pastes it onto the 2-digit state
  code, coerces to numeric, and asserts every result is a valid 7-digit code —
  failing loud on both short codes (lost leading zeros) and missing/`NA` codes.
- **Both `clean_agro_cnefe()` and `clean_cnefe10()` now call the helper** instead
  of each open-coding `as.numeric(paste0(cod_uf, cod_municipio))`.
- `clean_cnefe22()` is intentionally left alone — its source already delivers a
  full 7-digit code, so it stays a plain rename.
- The existing zero-overlap guard in `clean_agro_cnefe()` is kept (it is a
  stronger *semantic* check that the codes are real municipalities) but its
  comment was reworded, since the padding is now repaired one layer up.
- New spec test `tests/testthat/test-make_id_munic_7.R`.

## Review notes

Ran `/simplify` (reworded the now-stale guard comment, trimmed a redundant test
case) and a Codex review, which caught that the first version tolerated `NA`
municipality keys via `na.rm = TRUE`. The helper now rejects `NA` outputs too,
matching the project's fail-loud-on-missingness posture.

**One thing to confirm on the full data:** the `NA` rejection is a new assertion.
If the production (non-AC/RR) CNEFE inputs ever legitimately contain rows with a
missing state or municipality code, the pipeline will now stop there rather than
carry those rows through with empty geography. I could only run the fast unit
suite and dev-mode subset here, so please confirm a full run is clean.

## Testing

- `Rscript tests/testthat.R` — all 283 pass (1 unrelated skip).
- `air format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)