### PR TITLE
Neutralize crew GC-kill with a launch-handle keeper; panel stage back on crew workers (#82)

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -195,6 +195,48 @@ get_expected_municipality_count_for_config <- function(pipeline_config) {
 
 # ===== CREW CONTROLLER CONFIGURATION =====
 
+keep_crew_launch_handles <- function(controller) {
+  # Defend against the crew 1.3.1 launcher GC-kill bug (issue #82; upstream
+  # report wlandau/crew#253) by retaining a strong reference to every processx
+  # handle the launcher ever creates.
+  #
+  # Mechanism of the bug: crew's local launcher starts workers with
+  # processx::process$new(..., cleanup = TRUE), so a worker is SIGKILLed when
+  # its handle object is garbage-collected in the main process. Under churn or
+  # relaunch waves, launcher$scale() prunes launch-handle rows that can still
+  # reference LIVE, BUSY workers; the next gc() in the main tar_make() process
+  # then kills them mid-task ("worker crashed N consecutive times", silent
+  # death, victim is the longest-running batch). Holding our own reference to
+  # each handle makes the finalizer unreachable for the life of the run, so
+  # pruning becomes harmless. Verified against the minimal reproduction in
+  # docs/crew_bug_82/: with the keeper the long task survives churn + gc, and
+  # controller$terminate() still reaps all workers (no orphans).
+  #
+  # Implementation notes (crew internals, re-verify on any crew upgrade by
+  # running docs/crew_bug_82/minimal_repro.R):
+  # - launch_worker(call) is the public launcher method that creates and
+  #   returns the processx handle (crew_launcher_local); we wrap it so every
+  #   handle is also appended to `keeper`, which lives in the wrapper's
+  #   closure and stays reachable as long as the launcher itself.
+  # - The wrapper must be installed with assign() into the launcher
+  #   environment: `controller$launcher$launch_worker <- ...` fails because
+  #   R's compound assignment writes the launcher back through the
+  #   controller's read-only `launcher` active binding.
+  launcher <- controller$launcher
+  keeper <- new.env(parent = emptyenv())
+  keeper$handles <- list()
+  orig_launch_worker <- launcher$launch_worker
+  wrapper <- function(call) {
+    handle <- orig_launch_worker(call)
+    keeper$handles[[length(keeper$handles) + 1L]] <- handle
+    handle
+  }
+  unlockBinding("launch_worker", launcher)
+  assign("launch_worker", wrapper, envir = launcher)
+  lockBinding("launch_worker", launcher)
+  invisible(controller)
+}
+
 get_crew_controllers <- function() {
   # Create crew controller group for parallel processing
   # Uses same configuration for both dev and production modes
@@ -207,22 +249,18 @@ get_crew_controllers <- function() {
   crew_log_dir <- "crew_logs"
   dir.create(crew_log_dir, showWarnings = FALSE, recursive = TRUE)
 
-  # IMPORTANT (issue #48): both controllers use seconds_idle = Inf and
-  # seconds_wall = Inf to disable worker churn. crew 1.3.1's local launcher
-  # spawns workers with processx::process$new(..., cleanup = TRUE), so a worker
-  # is SIGKILLed when its launch handle is garbage-collected in the main process.
-  # When a worker idle-exits (seconds_idle) or wall-retires (seconds_wall) and a
-  # replacement connects, the launcher prunes the old launch-handle rows -- but
-  # those rows can still reference LIVE, BUSY workers, and the next gc() in the
-  # main tar_make() process (targets sets garbage_collection = TRUE) then kills
-  # them mid-task. The symptom is "worker crashed N consecutive times" with a
-  # silent death: no R error, no segfault banner, and no kernel/oomd OOM entry
-  # (the victim is always the longest-running batch of the active stage). Setting
-  # both timers to Inf keeps workers persistent so their rows are never pruned
-  # while in use. Reproduced minimally: churn + main-process gc() kills a live
-  # worker with 3 workers and zero memory pressure; seconds_idle = Inf fixes it.
-  # crew only spawns workers on demand, so persistent workers cost nothing until
-  # used. File upstream at wlandau/crew.
+  # IMPORTANT (issues #48/#82, upstream wlandau/crew#253): two-layer defense
+  # against the crew 1.3.1 launcher GC-kill bug (see keep_crew_launch_handles()
+  # above for the mechanism):
+  # 1. keep_crew_launch_handles() on both controllers -- the primary fix.
+  #    Retains every launch handle so the SIGKILL finalizer can never fire on a
+  #    live worker, no matter what the launcher prunes.
+  # 2. seconds_idle = Inf and seconds_wall = Inf -- belt-and-braces. Persistent
+  #    workers minimize the churn that triggers pruning in the first place, and
+  #    crew only spawns workers on demand, so they cost nothing until used.
+  # Do not restore finite idle/wall timers or remove the keeper without
+  # confirming upstream is fixed (re-run docs/crew_bug_82/minimal_repro.R on
+  # any crew upgrade).
 
   # Standard controller for most tasks - optimized for 32-core machine
   controller_standard <- crew::crew_controller_local(
@@ -250,6 +288,9 @@ get_crew_controllers <- function() {
     garbage_collection = TRUE,
     options_local = crew::crew_options_local(log_directory = crew_log_dir)
   )
+
+  keep_crew_launch_handles(controller_standard)
+  keep_crew_launch_handles(controller_memory)
 
   # Return controller group
   controller_group <- crew::crew_controller_group(

--- a/R/config.R
+++ b/R/config.R
@@ -208,33 +208,40 @@ keep_crew_launch_handles <- function(controller) {
   # then kills them mid-task ("worker crashed N consecutive times", silent
   # death, victim is the longest-running batch). Holding our own reference to
   # each handle makes the finalizer unreachable for the life of the run, so
-  # pruning becomes harmless. Verified against the minimal reproduction in
-  # docs/crew_bug_82/: with the keeper the long task survives churn + gc, and
-  # controller$terminate() still reaps all workers (no orphans).
+  # pruning becomes harmless. docs/crew_bug_82/keeper_check.R re-runs the
+  # bug scenario through this function: with the keeper the long task survives
+  # churn + gc, and controller$terminate() still reaps all workers (no
+  # orphans).
   #
   # Implementation notes (crew internals, re-verify on any crew upgrade by
   # running docs/crew_bug_82/minimal_repro.R):
   # - launch_worker(call) is the public launcher method that creates and
   #   returns the processx handle (crew_launcher_local); we wrap it so every
-  #   handle is also appended to `keeper`, which lives in the wrapper's
+  #   handle is also appended to `handles`, which lives in the wrapper's
   #   closure and stays reachable as long as the launcher itself.
   # - The wrapper must be installed with assign() into the launcher
   #   environment: `controller$launcher$launch_worker <- ...` fails because
   #   R's compound assignment writes the launcher back through the
   #   controller's read-only `launcher` active binding.
   launcher <- controller$launcher
-  keeper <- new.env(parent = emptyenv())
-  keeper$handles <- list()
+  handles <- list()
   orig_launch_worker <- launcher$launch_worker
   wrapper <- function(call) {
     handle <- orig_launch_worker(call)
-    keeper$handles[[length(keeper$handles) + 1L]] <- handle
+    handles[[length(handles) + 1L]] <<- handle
     handle
   }
   unlockBinding("launch_worker", launcher)
   assign("launch_worker", wrapper, envir = launcher)
   lockBinding("launch_worker", launcher)
   invisible(controller)
+}
+
+crew_controller_local_kept <- function(...) {
+  # The only sanctioned way to build a local crew controller in this pipeline:
+  # constructing and installing the handle keeper are inseparable, so a future
+  # controller cannot silently skip the GC-kill protection (issue #82).
+  keep_crew_launch_handles(crew::crew_controller_local(...))
 }
 
 get_crew_controllers <- function() {
@@ -252,18 +259,19 @@ get_crew_controllers <- function() {
   # IMPORTANT (issues #48/#82, upstream wlandau/crew#253): two-layer defense
   # against the crew 1.3.1 launcher GC-kill bug (see keep_crew_launch_handles()
   # above for the mechanism):
-  # 1. keep_crew_launch_handles() on both controllers -- the primary fix.
-  #    Retains every launch handle so the SIGKILL finalizer can never fire on a
-  #    live worker, no matter what the launcher prunes.
+  # 1. crew_controller_local_kept() -- the primary fix. Every controller is
+  #    built with the handle keeper installed, so the SIGKILL finalizer can
+  #    never fire on a live worker, no matter what the launcher prunes.
   # 2. seconds_idle = Inf and seconds_wall = Inf -- belt-and-braces. Persistent
   #    workers minimize the churn that triggers pruning in the first place, and
   #    crew only spawns workers on demand, so they cost nothing until used.
   # Do not restore finite idle/wall timers or remove the keeper without
-  # confirming upstream is fixed (re-run docs/crew_bug_82/minimal_repro.R on
-  # any crew upgrade).
+  # confirming upstream is fixed: on any crew upgrade re-run
+  # docs/crew_bug_82/minimal_repro.R (does the bug still exist?) and
+  # docs/crew_bug_82/keeper_check.R (does the keeper still defeat it?).
 
   # Standard controller for most tasks - optimized for 32-core machine
-  controller_standard <- crew::crew_controller_local(
+  controller_standard <- crew_controller_local_kept(
     name = "standard",
     workers = 28, # Max workers - crew only spawns as needed
     seconds_idle = Inf, # no idle churn (see issue #48 note above)
@@ -277,7 +285,7 @@ get_crew_controllers <- function() {
 
   # Memory-limited controller for CNEFE operations: fewer workers but more memory
   # per worker.
-  controller_memory <- crew::crew_controller_local(
+  controller_memory <- crew_controller_local_kept(
     name = "memory_limited",
     workers = 8, # Max workers for memory-intensive tasks
     seconds_idle = Inf, # no idle churn (see issue #48 note above)
@@ -288,9 +296,6 @@ get_crew_controllers <- function() {
     garbage_collection = TRUE,
     options_local = crew::crew_options_local(log_directory = crew_log_dir)
   )
-
-  keep_crew_launch_handles(controller_standard)
-  keep_crew_launch_handles(controller_memory)
 
   # Return controller group
   controller_group <- crew::crew_controller_group(

--- a/_targets.R
+++ b/_targets.R
@@ -578,19 +578,18 @@ list(
     },
     pattern = map(panel_batch_ids),
     iteration = "list",
-    # deployment = "main": run panel linkage in the local process, NOT on crew
-    # workers. The mega-city batches (Sao Paulo ~19.5k station-records, Rio ~14.6k)
-    # run 25+ min single-threaded, and crew 1.3.1's launcher GC-kills any worker
-    # that stays alive long enough for the main process to garbage-collect its
-    # (bug-pruned) launch handle -- so these long batches were killed every run,
-    # deterministically, on the standard controller (issue #48, #82). The batches
-    # are proven correct in isolation; crew (latest on CRAN, no upstream fix) is
-    # the only thing that kills them. Running on main sidesteps the crew launcher
-    # entirely. Cost: the panel stage is sequential (~1-1.5 h), dominated by the
-    # two mega cities which are the critical path at any width anyway.
-    deployment = "main",
-    storage = "main",
-    retrieval = "main"
+    # Back on crew workers: the crew 1.3.1 GC-kill that forced this stage onto
+    # the main process (issue #82) is neutralized by keep_crew_launch_handles()
+    # in get_crew_controllers(). The mega-city batches (Sao Paulo, Rio) run 25+
+    # min single-threaded and were this bug's reliable victims -- if this stage
+    # ever dies again with "worker crashed N consecutive times", see
+    # docs/crew_bug_82/ before re-pinning it to main.
+    deployment = "worker",
+    storage = "worker",
+    retrieval = "worker",
+    resources = tar_resources(
+      crew = tar_resources_crew(controller = "standard")
+    )
   ),
 
   ## Combine panel IDs from all batches

--- a/docs/crew_bug_82/README.md
+++ b/docs/crew_bug_82/README.md
@@ -47,12 +47,22 @@ Ubuntu 24.04, local `crew_controller_local` workers.
 
 ## Workarounds applied in this repo
 
-1. `get_crew_controllers()` in `R/config.R`: `seconds_idle = Inf` and
-   `seconds_wall = Inf` on both controllers (stops idle/wall churn). Necessary
-   but not sufficient on its own.
-2. `panel_ids_by_batch` in `_targets.R`: `deployment = "main"` so the long
-   mega-city linkage batches never touch the crew launcher. This is the change
-   that actually unblocked the release run.
+1. **Handle keeper (primary)** — `keep_crew_launch_handles()` in `R/config.R`,
+   applied to both controllers: wraps the launcher's `launch_worker()` so every
+   processx handle it creates is also retained in a keeper list. The SIGKILL
+   finalizer can then never fire on a live worker, no matter which launch rows
+   crew prunes. Verified against `minimal_repro.R`: with the keeper the long
+   task survives churn + main-process `gc()`, and `terminate()` still reaps all
+   workers (no orphans). This made it safe to move `panel_ids_by_batch` back to
+   crew workers (it was pinned to `deployment = "main"` during the v0.15
+   release run).
+2. `get_crew_controllers()` in `R/config.R`: `seconds_idle = Inf` and
+   `seconds_wall = Inf` on both controllers (stops idle/wall churn).
+   Belt-and-braces; necessary but not sufficient on its own.
+
+Filed upstream as [wlandau/crew#253](https://github.com/wlandau/crew/issues/253).
+On any crew upgrade, re-run `minimal_repro.R`; once it stops reproducing, the
+handle keeper and the `Inf` timers can be dropped.
 
 See issue #82 for the full history, including the initial (wrong) memory
 diagnosis and how it was corrected.

--- a/docs/crew_bug_82/README.md
+++ b/docs/crew_bug_82/README.md
@@ -33,9 +33,14 @@ batch, 25+ min).
   was insufficient for the real pipeline: the production cascade needs a *first*
   kill (from scale-up / heavy-task timing) that trivial sleep tasks don't
   produce. Left here as a documented dead-end.
+- `keeper_check.R` — the same scenario as `minimal_repro.R` but run through the
+  shipped workaround, `keep_crew_launch_handles()` from `R/config.R`. The long
+  task must **succeed**; exits non-zero if the keeper stops working. This is
+  the positive control that gates the workaround (run from the repo root).
 
 ```sh
 Rscript docs/crew_bug_82/minimal_repro.R          # reproduces (churn + gc)
+Rscript docs/crew_bug_82/keeper_check.R           # keeper defeats it (must PASS)
 Rscript docs/crew_bug_82/scaled_repro.R yes       # 28 workers, Inf idle, WITH main gc  (did not repro)
 Rscript docs/crew_bug_82/scaled_repro.R no         # WITHOUT main gc
 ```
@@ -48,21 +53,24 @@ Ubuntu 24.04, local `crew_controller_local` workers.
 ## Workarounds applied in this repo
 
 1. **Handle keeper (primary)** — `keep_crew_launch_handles()` in `R/config.R`,
-   applied to both controllers: wraps the launcher's `launch_worker()` so every
-   processx handle it creates is also retained in a keeper list. The SIGKILL
-   finalizer can then never fire on a live worker, no matter which launch rows
-   crew prunes. Verified against `minimal_repro.R`: with the keeper the long
-   task survives churn + main-process `gc()`, and `terminate()` still reaps all
-   workers (no orphans). This made it safe to move `panel_ids_by_batch` back to
-   crew workers (it was pinned to `deployment = "main"` during the v0.15
-   release run).
+   installed on every controller via `crew_controller_local_kept()` (the only
+   sanctioned local-controller constructor in the pipeline): wraps the
+   launcher's `launch_worker()` so every processx handle it creates is also
+   retained in a keeper list. The SIGKILL finalizer can then never fire on a
+   live worker, no matter which launch rows crew prunes. `keeper_check.R`
+   verifies this end-to-end: with the keeper the long task survives churn +
+   main-process `gc()`, and `terminate()` still reaps all workers (no
+   orphans). This made it safe to move `panel_ids_by_batch` back to crew
+   workers (it was pinned to `deployment = "main"` during the v0.15 release
+   run).
 2. `get_crew_controllers()` in `R/config.R`: `seconds_idle = Inf` and
    `seconds_wall = Inf` on both controllers (stops idle/wall churn).
    Belt-and-braces; necessary but not sufficient on its own.
 
 Filed upstream as [wlandau/crew#253](https://github.com/wlandau/crew/issues/253).
-On any crew upgrade, re-run `minimal_repro.R`; once it stops reproducing, the
-handle keeper and the `Inf` timers can be dropped.
+On any crew upgrade, re-run `minimal_repro.R` (does the bug still exist?) and
+`keeper_check.R` (does the keeper still defeat it?). Once `minimal_repro.R`
+stops reproducing, the handle keeper and the `Inf` timers can be dropped.
 
 See issue #82 for the full history, including the initial (wrong) memory
 diagnosis and how it was corrected.

--- a/docs/crew_bug_82/keeper_check.R
+++ b/docs/crew_bug_82/keeper_check.R
@@ -1,0 +1,73 @@
+# Does keep_crew_launch_handles() (R/config.R) still defeat the crew launcher
+# GC-kill bug? Runs the exact minimal_repro.R scenario (churn + main-process
+# gc) through the shipped keeper; the long task must SUCCEED where the
+# unpatched repro crashes it in ~10s. Run from the repo root:
+#   Rscript docs/crew_bug_82/keeper_check.R
+# Exits non-zero on failure. Re-run together with minimal_repro.R on any
+# crew/mirai/processx upgrade: once minimal_repro.R stops reproducing the
+# crash upstream is fixed and the keeper can be dropped; until then this
+# script gates that the workaround still works.
+suppressMessages(library(crew))
+suppressMessages(library(data.table)) # loaded by R/config.R
+source("R/config.R")
+
+x <- crew_controller_local(
+  name = "keeper_check",
+  workers = 3,
+  seconds_idle = 2 # induce churn like minimal_repro.R
+)
+keep_crew_launch_handles(x)
+x$start()
+
+# One long task (the "Sao Paulo batch") ...
+x$push(
+  command = {
+    pid <- Sys.getpid()
+    for (i in 1:60) {
+      Sys.sleep(1)
+    }
+    pid
+  },
+  name = "long_task"
+)
+# ... plus short tasks so workers finish, idle-exit, and get replaced.
+for (i in 1:2) {
+  x$push(command = Sys.sleep(0.5), name = paste0("short_", i))
+}
+
+t0 <- Sys.time()
+round1 <- 0L
+status <- NA_character_
+while (difftime(Sys.time(), t0, units = "secs") < 90) {
+  out <- x$pop() # pop() also triggers scale()
+  if (is.null(out) == FALSE) {
+    cat(
+      format(Sys.time(), "%H:%M:%S"),
+      "popped:",
+      out$name,
+      "status:",
+      out$status,
+      "\n"
+    )
+    if (identical(out$name, "long_task")) {
+      status <- out$status
+      break
+    }
+  }
+  # After the first wave of short tasks completes and idles out,
+  # push more short tasks to force NEW launches + connections
+  el <- as.numeric(difftime(Sys.time(), t0, units = "secs"))
+  if (el > 8 && round1 < 4L) {
+    round1 <- round1 + 1L
+    x$push(command = Sys.sleep(0.5), name = paste0("wave2_", round1))
+  }
+  gc(verbose = FALSE) # main-process GC, as targets does with garbage_collection = TRUE
+  Sys.sleep(0.5)
+}
+
+x$terminate()
+cat("\nRESULT: long task status =", status, "\n")
+if (identical(status, "success") == FALSE) {
+  stop("keeper_check FAILED: the handle keeper no longer prevents the GC-kill")
+}
+cat("PASS: keep_crew_launch_handles() defeats the GC-kill scenario\n")


### PR DESCRIPTION
## What this PR does (high level)

The pipeline currently runs its slowest stage — building the panel identifiers that link polling stations across election years — one municipality batch at a time in a single process. That was a defensive retreat: a bug in the `crew` package (the library that manages our parallel workers) was silently killing whichever worker ran the longest, and the panel stage's São Paulo batch was its most reliable victim. This PR adds a small, targeted countermeasure that makes the bug unable to fire at all, and moves the panel stage back onto parallel workers, recovering roughly 1–1.5 hours of wall time on a full production rebuild.

## The countermeasure

crew 1.3.1 kills a worker when the R object holding its process handle is garbage-collected in the main process (`processx` `cleanup = TRUE` finalizer), and crew's launcher drops its own reference to that handle while the worker is still alive and busy (upstream report: [wlandau/crew#253](https://github.com/wlandau/crew/issues/253), filed from this repo's issue #82). `keep_crew_launch_handles()` wraps the launcher's `launch_worker()` method so every handle it ever creates is also retained by us for the life of the run. With a permanent reference in place, the finalizer can never fire, so crew's reference-dropping becomes harmless. Both controllers are now built via `crew_controller_local_kept()`, which makes constructing a local controller and installing the keeper inseparable.

## Changes

- `R/config.R`: `keep_crew_launch_handles()` + `crew_controller_local_kept()`; both controllers use it. The `seconds_idle = Inf` / `seconds_wall = Inf` timers stay as a second layer (they minimize the churn that triggers the bug's preconditions).
- `_targets.R`: `panel_ids_by_batch` reverted from `deployment = "main"` (commit `ac6ef9d`) back to `deployment = "worker"` on the standard controller.
- `docs/crew_bug_82/`: new `keeper_check.R` — the minimal-repro kill scenario run through the shipped keeper, exiting non-zero if the workaround ever stops working; README updated with the upstream issue link and the two-script revisit procedure for future crew upgrades.

## Verification

- `docs/crew_bug_82/minimal_repro.R` (unpatched control): still crashes the long task in ~8s on this machine — bug present in crew 1.3.1.
- `docs/crew_bug_82/keeper_check.R` (shipped fix): long task survives the identical churn + gc scenario, PASS; `terminate()` reaps all workers, no orphans.
- Full dev-mode rebuild (`TAR_PROJECT=dev tar_make()`): `panel_ids_by_batch` ran as 5 parallel branches on crew workers, zero crashes. The run then stopped at `release_gates` — a pre-existing, unrelated dev-calibration bug (Gate 7 applies the national 85% coverage floor to the AC/RR dev subset), filed as #83.
- Unit suite: 283 pass, 0 fail. `air format --check .` clean.
- Reviews: 4-agent `/simplify` pass (two findings applied — closure-local list instead of a keeper environment; keeper folded into the constructor — plus the `keeper_check.R` gap; one skipped — the explicit standard-controller `resources` block restates the pipeline default but matches file convention). Codex review: no findings.

## Caveats

The keeper touches crew internals (it rebinds `launch_worker` on the launcher instance), so it is a documented local workaround, not a root-cause fix. The revisit procedure on any crew upgrade is recorded in `docs/crew_bug_82/README.md` and in the `R/config.R` comments. The real proof of the panel-stage revert is a full production rebuild, which needs to be run on your schedule.

Closes nothing; tracks #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)