### PR TITLE
Fix panel-coordinate & pred_dist regressions; preserve 0.141 published schema

### DIFF
--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -527,6 +527,12 @@ finalize_coords <- function(locais, model_predictions, tsegeocoded_locais) {
   geocoded_locais[, final_long := ifelse(is.na(tse_long), pred_long, tse_long)]
   geocoded_locais[, final_lat := ifelse(is.na(tse_lat), pred_lat, tse_lat)]
 
+  # pred_dist is the predicted error of the CHOSEN (final) coordinate. When the
+  # TSE supplies it, the chosen coordinate is ground truth, so its predicted
+  # error is 0. This is the documented behavior and also lets downstream accuracy
+  # filters and the panel coordinate picker treat TSE-covered rows as exact.
+  geocoded_locais[!is.na(tse_long) & !is.na(tse_lat), pred_dist := 0]
+
   return(geocoded_locais)
 }
 

--- a/R/panel_creation.R
+++ b/R/panel_creation.R
@@ -91,10 +91,13 @@ process_year_pairs <- function(panel, best_pairs, year_from, year_to) {
 #' @return Data table with panel IDs and coordinates
 #' @export
 make_panel_ids <- function(panel_ids_df, panel_ids_states, geocoded_locais) {
-  # Standardize column names
+  # Standardize the panel-id tables' column names. geocoded_locais is deliberately
+  # NOT standardized: it is the shared canonical target, so an inplace rename here
+  # would corrupt the columns other consumers (export, release gates) read from
+  # the same in-memory object - and the columns used below (local_id, ano,
+  # final_long, final_lat, pred_dist) are already in their final form anyway.
   standardize_column_names(panel_ids_df, inplace = TRUE)
   standardize_column_names(panel_ids_states, inplace = TRUE)
-  standardize_column_names(geocoded_locais, inplace = TRUE)
 
   panel_ids <- rbindlist(list(panel_ids_df, panel_ids_states))
 

--- a/R/panel_creation.R
+++ b/R/panel_creation.R
@@ -115,11 +115,13 @@ make_panel_ids <- function(panel_ids_df, panel_ids_states, geocoded_locais) {
   # when every one of its years failed to geocode (rare). This is why the model
   # coordinates matter here: without them, panels whose years predate TSE ground
   # truth (2018) would all come out blank.
-  panel_ids_best <- panel_ids[
-    !is.na(long) & !is.na(lat)
-  ][
-    order(panel_id, pred_dist, -ano)
-  ][, .SD[1], by = .(panel_id)][, .(panel_id, long, lat, pred_dist)]
+  # unique(by=) keeps the first row per panel on the already-sorted table, which
+  # is the smallest-pred_dist / most-recent row - the same pick as .SD[1] by
+  # group, without the per-group allocation.
+  panel_ids_best <- unique(
+    panel_ids[!is.na(long) & !is.na(lat)][order(panel_id, pred_dist, -ano)],
+    by = "panel_id"
+  )[, .(panel_id, long, lat, pred_dist)]
 
   # Replace the per-station coordinates with the chosen panel-level coordinate.
   panel_ids[, c("long", "lat", "pred_dist", "ano") := NULL]
@@ -128,8 +130,8 @@ make_panel_ids <- function(panel_ids_df, panel_ids_states, geocoded_locais) {
     on = .(panel_id),
     nomatch = NA
   ]
-
-  panel_ids[, .(panel_id, local_id, long, lat, pred_dist)]
+  setcolorder(panel_ids, c("panel_id", "local_id", "long", "lat", "pred_dist"))
+  panel_ids[]
 }
 
 #' Create panel dataset from matched pairs

--- a/R/panel_creation.R
+++ b/R/panel_creation.R
@@ -98,30 +98,38 @@ make_panel_ids <- function(panel_ids_df, panel_ids_states, geocoded_locais) {
 
   panel_ids <- rbindlist(list(panel_ids_df, panel_ids_states))
 
-  # Join with geocoded locais using data.table syntax
+  # Attach each station-year's final coordinate (the TSE official coordinate when
+  # available, otherwise the model's selection) and its predicted error. pred_dist
+  # is 0 for TSE-covered rows and the model's predicted distance otherwise, so
+  # ordering a panel's years by pred_dist puts ground-truth coordinates first and
+  # the most confident model coordinate next.
   panel_ids <- geocoded_locais[
     panel_ids,
     on = .(local_id),
     nomatch = NA
-  ][, .(local_id, panel_id, ano, long = tse_long, lat = tse_lat)]
+  ][, .(local_id, panel_id, ano, long = final_long, lat = final_lat, pred_dist)]
 
-  # For each panel_id, get coordinates from most recent year
-  # (TSE data doesn't have pred_dist)
+  # For each panel, choose the single most accurate coordinate: smallest
+  # pred_dist, ties broken toward the most recent year. Only station-years that
+  # actually carry a coordinate compete, so a panel is left uncoordinated only
+  # when every one of its years failed to geocode (rare). This is why the model
+  # coordinates matter here: without them, panels whose years predate TSE ground
+  # truth (2018) would all come out blank.
   panel_ids_best <- panel_ids[
-    order(panel_id, -ano)
-  ][, .SD[1], by = .(panel_id)][, .(panel_id, long, lat)]
+    !is.na(long) & !is.na(lat)
+  ][
+    order(panel_id, pred_dist, -ano)
+  ][, .SD[1], by = .(panel_id)][, .(panel_id, long, lat, pred_dist)]
 
-  # Remove coordinates from panel_ids
-  panel_ids[, c("long", "lat", "ano") := NULL]
-
-  # Join with best coordinates using data.table syntax
+  # Replace the per-station coordinates with the chosen panel-level coordinate.
+  panel_ids[, c("long", "lat", "pred_dist", "ano") := NULL]
   panel_ids <- panel_ids_best[
     panel_ids,
     on = .(panel_id),
     nomatch = NA
   ]
 
-  return(panel_ids)
+  panel_ids[, .(panel_id, local_id, long, lat, pred_dist)]
 }
 
 #' Create panel dataset from matched pairs

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -751,13 +751,78 @@ create_municipality_batch_assignments <- function(muni_codes, batch_size = 50, m
 # ===== DATA EXPORT FUNCTIONS =====
 # These functions were moved from data_export.R
 
+# Column names and order of the published geocoded file, preserved from the
+# 0.141 release so downstream code that reads it keeps working. Internally the
+# pipeline names the recommended coordinate final_long/final_lat (to
+# disambiguate from pred_*/tse_*); the published file calls them long/lat.
+GEOCODED_EXPORT_SCHEMA <- c(
+  "local_id",
+  "ano",
+  "sg_uf",
+  "cd_localidade_tse",
+  "cod_localidade_ibge",
+  "nr_zona",
+  "nr_locvot",
+  "nr_cep",
+  "nm_localidade",
+  "nm_locvot",
+  "ds_endereco",
+  "ds_bairro",
+  "pred_long",
+  "pred_lat",
+  "pred_dist",
+  "tse_long",
+  "tse_lat",
+  "long",
+  "lat"
+)
+
+#' Map the internal geocoded table to the published 0.141-compatible schema.
+#'
+#' Renames final_long/final_lat to long/lat and reorders columns to
+#' GEOCODED_EXPORT_SCHEMA. Pure (returns a new table; does not mutate the input),
+#' so it is unit-testable and safe to call on a shared target object. Fails loud
+#' if the expected columns are absent.
+#'
+#' @param geocoded_locais Internal geocoded table (with final_long/final_lat).
+#' @return A data.table with exactly the published columns, in 0.141 order.
+#' @export
+to_geocoded_export_schema <- function(geocoded_locais) {
+  # Read-only select: renames final_long/final_lat inline and fixes column order
+  # in one pass, returning a new data.table without mutating the input.
+  as.data.table(geocoded_locais)[, .(
+    local_id,
+    ano,
+    sg_uf,
+    cd_localidade_tse,
+    cod_localidade_ibge,
+    nr_zona,
+    nr_locvot,
+    nr_cep,
+    nm_localidade,
+    nm_locvot,
+    ds_endereco,
+    ds_bairro,
+    pred_long,
+    pred_lat,
+    pred_dist,
+    tse_long,
+    tse_lat,
+    long = final_long,
+    lat = final_lat
+  )]
+}
+
 #' Export geocoded locations to file
 #'
 #' @param geocoded_locais Geocoded locations data
 #' @return Path to exported file
 #' @export
 export_geocoded_locais <- function(geocoded_locais) {
-  fwrite(geocoded_locais, "./output/geocoded_polling_stations.csv.gz")
+  fwrite(
+    to_geocoded_export_schema(geocoded_locais),
+    "./output/geocoded_polling_stations.csv.gz"
+  )
   "./output/geocoded_polling_stations.csv.gz"
 }
 

--- a/R/validation.R
+++ b/R/validation.R
@@ -971,6 +971,22 @@ validate_release_gates <- function(geocoded_locais, tse_coverage, tse_raw_availa
     )
   }
 
+  # Gate 8: pred_dist is 0 for TSE-covered stations. Their shipped coordinate is
+  # TSE ground truth, so its predicted error must be 0 (documented behavior). A
+  # non-zero value means finalize_coords stopped zeroing it, which breaks
+  # accuracy filtering and the panel coordinate picker (both order by pred_dist).
+  # Guarded on schema so a missing column stays Gate 2's failure, not a raw error.
+  if (all(c("tse_long", "tse_lat", "pred_dist") %in% names(dt))) {
+    tse_rows <- dt[!is.na(tse_long) & !is.na(tse_lat)]
+    n_bad_preddist <- tse_rows[is.na(pred_dist) | pred_dist != 0, .N]
+    if (n_bad_preddist > 0) {
+      add_fail(
+        "Gate 8 (pred_dist): %d TSE-covered rows have non-zero pred_dist (expected 0 for ground-truth coordinates)",
+        n_bad_preddist
+      )
+    }
+  }
+
   summary <- list(
     passed = length(failures) == 0,
     failures = failures,
@@ -994,6 +1010,67 @@ validate_release_gates <- function(geocoded_locais, tse_coverage, tse_raw_availa
     paste(present_years, collapse = ","),
     n_2024,
     cov_2024
+  ))
+  summary
+}
+
+# Maximum share of panel rows allowed to ship without a coordinate. The panel
+# file assigns each panel its single most accurate coordinate, and a panel is
+# uncoordinated only when every one of its station-years failed to geocode -
+# which is rare, so the real rate sits well under 1%. A larger rate means the
+# panel step stopped consulting the model coordinates (the regression that read
+# tse_long/tse_lat only left ~13% of panels blank).
+RELEASE_PANEL_COORD_NA_MAX_PCT <- 1
+
+#' Fail-loud release gate for the panel-id output.
+#'
+#' Sibling to validate_release_gates(): that gate guards the geocoded export;
+#' this one guards panel_ids.csv.gz. Stops the build if the panel file drops its
+#' accuracy column or leaves too many panels without a coordinate.
+#'
+#' @param panel_ids The panel_ids target (panel_id, local_id, long, lat, pred_dist).
+#' @return A summary list; stop()s with the specific failures otherwise.
+#' @export
+validate_panel_release <- function(panel_ids) {
+  dt <- if (is.data.table(panel_ids)) panel_ids else as.data.table(panel_ids)
+  failures <- character(0)
+  add_fail <- function(...) failures <<- c(failures, sprintf(...))
+
+  # Gate P1: the accuracy-filter column must reach the output.
+  if (!("pred_dist" %in% names(dt))) {
+    add_fail("Gate P1 (schema): panel_ids is missing the pred_dist column")
+  }
+
+  # Gate P2: coordinates present for essentially every panel.
+  has_coords <- all(c("long", "lat") %in% names(dt))
+  coord_na_pct <- if (has_coords) 100 * mean(is.na(dt$long) | is.na(dt$lat)) else NA_real_
+  if (!has_coords) {
+    add_fail("Gate P2 (coords): panel_ids is missing long/lat columns")
+  } else if (coord_na_pct > RELEASE_PANEL_COORD_NA_MAX_PCT) {
+    add_fail(
+      "Gate P2 (coords): %.2f%% of panel rows lack a coordinate (> %g%% max) - the panel step is likely ignoring model coordinates",
+      coord_na_pct,
+      RELEASE_PANEL_COORD_NA_MAX_PCT
+    )
+  }
+
+  summary <- list(
+    passed = length(failures) == 0,
+    failures = failures,
+    n_rows = nrow(dt),
+    coord_na_pct = coord_na_pct
+  )
+
+  if (length(failures) > 0) {
+    stop(sprintf(
+      "Panel release gates FAILED (do not ship):\n  - %s",
+      paste(failures, collapse = "\n  - ")
+    ))
+  }
+  message(sprintf(
+    "Panel release gates PASSED: %d rows; %.2f%% without a coordinate",
+    summary$n_rows,
+    coord_na_pct
   ))
   summary
 }

--- a/R/validation.R
+++ b/R/validation.R
@@ -839,7 +839,18 @@ RELEASE_TSE_VINTAGES <- c(2018L, 2020L, 2022L, 2024L)
 # real regression (decision 2).
 RELEASE_TSE_JOIN_SLACK <- 5L
 
-validate_release_gates <- function(geocoded_locais, tse_coverage, tse_raw_availability, export_paths, dev_mode) {
+validate_release_gates <- function(
+  geocoded_locais,
+  tse_coverage,
+  tse_raw_availability,
+  export_paths,
+  dev_mode,
+  panel_gate = NULL
+) {
+  # panel_gate is a dependency-only argument: passing the panel_release_gates
+  # target makes this canonical release check depend on the panel gate, so
+  # building release_gates also runs validate_panel_release() (which stops the
+  # build itself on failure). It is not otherwise read here.
   # Read-only, so avoid a defensive deep copy of the ~945k-row national table
   # when it already arrives as a data.table (it does, from finalize_coords()).
   dt <- if (is.data.table(geocoded_locais)) {

--- a/R/validation.R
+++ b/R/validation.R
@@ -1000,6 +1000,25 @@ validate_release_gates <- function(
     }
   }
 
+  # Gate 9: the PUBLISHED geocoded schema is exactly the 0.141 column set and
+  # order. Gates 2-3 check the internal final_* table, but the file is written
+  # through to_geocoded_export_schema() (final_long/final_lat -> long/lat, 0.141
+  # order); this gate runs that mapper and checks its output, so a regression in
+  # the mapper - a dropped/reordered published column - is caught here instead of
+  # shipping a broken header. A one-row sample suffices: the schema is
+  # data-independent.
+  published_cols <- tryCatch(
+    names(to_geocoded_export_schema(head(dt, 1L))),
+    error = function(e) character(0)
+  )
+  if (!identical(published_cols, GEOCODED_EXPORT_SCHEMA)) {
+    add_fail(
+      "Gate 9 (published schema): export mapper output does not match the 0.141 schema.\n    expected: %s\n    got: %s",
+      paste(GEOCODED_EXPORT_SCHEMA, collapse = ", "),
+      paste(published_cols, collapse = ", ")
+    )
+  }
+
   summary <- list(
     passed = length(failures) == 0,
     failures = failures,

--- a/R/validation.R
+++ b/R/validation.R
@@ -977,8 +977,10 @@ validate_release_gates <- function(geocoded_locais, tse_coverage, tse_raw_availa
   # accuracy filtering and the panel coordinate picker (both order by pred_dist).
   # Guarded on schema so a missing column stays Gate 2's failure, not a raw error.
   if (all(c("tse_long", "tse_lat", "pred_dist") %in% names(dt))) {
-    tse_rows <- dt[!is.na(tse_long) & !is.na(tse_lat)]
-    n_bad_preddist <- tse_rows[is.na(pred_dist) | pred_dist != 0, .N]
+    n_bad_preddist <- dt[
+      !is.na(tse_long) & !is.na(tse_lat) & (is.na(pred_dist) | pred_dist != 0),
+      .N
+    ]
     if (n_bad_preddist > 0) {
       add_fail(
         "Gate 8 (pred_dist): %d TSE-covered rows have non-zero pred_dist (expected 0 for ground-truth coordinates)",

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ The dataset (`geocoded_polling_stations.csv.gz`) contains the following variable
 
 - `tse_long`: Longitude provided by the TSE. This is only available for a subset of data.
 
-- `final_long`: Longitude to use for analysis. This is the coordinate provided by the TSE when available (`tse_long`), and otherwise the coordinate selected by our model (`pred_long`). In releases prior to 0.15 this column was named `long`.
+- `long`: Longitude to use for analysis. This is the coordinate provided by the TSE when available (`tse_long`), and otherwise the coordinate selected by our model (`pred_long`).
 
-- `final_lat`: Latitude to use for analysis. This is the coordinate provided by the TSE when available (`tse_lat`), and otherwise the coordinate selected by our model (`pred_lat`). In releases prior to 0.15 this column was named `lat`.
+- `lat`: Latitude to use for analysis. This is the coordinate provided by the TSE when available (`tse_lat`), and otherwise the coordinate selected by our model (`pred_lat`).
 
 ### Panel Identifiers
 We also created panel identifiers that track a given polling station over time. Because panel identifiers provided by the electoral authorities can change over time, we must use a fuzzy matching procedure to create our own panel identifiers. The process implemented to generate the panel identifiers consists of six stages. First, we subset the data at the state level for each electoral year. Then, we generate every possible pair of polling stations at the municipality level for every consecutive electoral year. This can be as few as three possible pairs for the least populous municipality in Brazil, Serra da Saudade-MG, which had one polling station in 2006 and three in 2008, or as many as millions of pairs for the most populous municipality, São Paulo-SP, which has over 1,500 polling stations in each electoral year. The next step is to calculate the [Jaro-Winkler](https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance) string similarity for each possible pair on two strings: the normalized name and the normalized address of the location. 

--- a/_targets.R
+++ b/_targets.R
@@ -605,10 +605,13 @@ list(
   tar_target(
     name = panel_ids,
     command = {
-      # The combined panel IDs are already properly formatted
-      # Just need to add coordinates using the existing function
-      # Pass empty data.table for df_panels since all states are now combined
-      make_panel_ids(data.table(), panel_ids_combined, tsegeocoded_locais)
+      # The combined panel IDs are already properly formatted; make_panel_ids()
+      # attaches each panel's best coordinate. Pass the full geocoded output
+      # (geocoded_locais) - not the TSE-only table - so panels whose years
+      # predate TSE ground truth still get the model's coordinate, and pred_dist
+      # is available to pick the most accurate one. Empty df_panels because all
+      # states are already combined.
+      make_panel_ids(data.table(), panel_ids_combined, geocoded_locais)
     },
     format = "qs"
   ),
@@ -1200,6 +1203,13 @@ list(
       export_paths = c(geocoded_export, panelid_export),
       dev_mode = pipeline_config$dev_mode
     ),
+    cue = tar_cue(mode = "always")
+  ),
+  ## Panel-output release gate: guards panel_ids.csv.gz (accuracy column present,
+  ## coordinates assigned to essentially every panel). Sibling to release_gates.
+  tar_target(
+    name = panel_release_gates,
+    command = validate_panel_release(panel_ids),
     cue = tar_cue(mode = "always")
   ),
   ## Data Quality Monitoring

--- a/_targets.R
+++ b/_targets.R
@@ -1201,12 +1201,15 @@ list(
       tse_coverage = tse_coverage,
       tse_raw_availability = tse_raw_availability,
       export_paths = c(geocoded_export, panelid_export),
-      dev_mode = pipeline_config$dev_mode
+      dev_mode = pipeline_config$dev_mode,
+      panel_gate = panel_release_gates
     ),
     cue = tar_cue(mode = "always")
   ),
   ## Panel-output release gate: guards panel_ids.csv.gz (accuracy column present,
-  ## coordinates assigned to essentially every panel). Sibling to release_gates.
+  ## coordinates assigned to essentially every panel). Sibling to release_gates,
+  ## and a dependency of it (via panel_gate) so the canonical release check
+  ## can't be built without also running this one.
   tar_target(
     name = panel_release_gates,
     command = validate_panel_release(panel_ids),

--- a/tests/integration/dev_pipeline_check.R
+++ b/tests/integration/dev_pipeline_check.R
@@ -55,11 +55,13 @@ run_check <- function(desc, code) {
 br_lat <- c(-34, 6)
 br_long <- c(-74, -34)
 
-# Columns validate_final_output requires on the geocoded output (_targets.R).
+# Columns required on the *published* geocoded file. The recommended coordinate
+# ships as long/lat (0.141-compatible names); the internal table calls it
+# final_long/final_lat and is remapped at export by to_geocoded_export_schema().
 geocoded_required_cols <- c(
   "local_id",
-  "final_lat",
-  "final_long",
+  "lat",
+  "long",
   "ano",
   "nr_zona",
   "nr_locvot",
@@ -105,10 +107,10 @@ results <- c(
 
   # 4. Coordinate sanity + not-all-NA. (tripwire: C5 geocodebr silent-vanish.)
   run_check("4. coordinates are within Brazil and not entirely NA", {
-    expect_false(all(is.na(geocoded$final_lat)))
-    expect_false(all(is.na(geocoded$final_long)))
-    lat <- geocoded$final_lat[!is.na(geocoded$final_lat)]
-    long <- geocoded$final_long[!is.na(geocoded$final_long)]
+    expect_false(all(is.na(geocoded$lat)))
+    expect_false(all(is.na(geocoded$long)))
+    lat <- geocoded$lat[!is.na(geocoded$lat)]
+    long <- geocoded$long[!is.na(geocoded$long)]
     expect_true(all(lat >= br_lat[1] & lat <= br_lat[2]))
     expect_true(all(long >= br_long[1] & long <= br_long[2]))
     expect_false(all(is.na(panel$lat)))

--- a/tests/testthat/test-make_panel_ids.R
+++ b/tests/testthat/test-make_panel_ids.R
@@ -1,9 +1,11 @@
 ## Spec tests for make_panel_ids() (R/panel_creation.R).
-## Stacks the main and state panel-id tables, joins TSE coordinates from
-## geocoded_locais, and assigns every station in a panel the coordinates of the
-## panel's most recent year. Assertions are keyed on local_id, not row order.
+## Stacks the main and state panel-id tables, joins the final coordinate
+## (TSE-when-available, otherwise the model's selection) from geocoded_locais,
+## and assigns every station in a panel the single most accurate coordinate the
+## panel offers: smallest pred_dist, ties broken toward the most recent year.
+## Assertions are keyed on local_id, not row order.
 
-test_that("make_panel_ids gives every station in a panel its most-recent-year coordinates", {
+test_that("make_panel_ids picks each panel's smallest-pred_dist coordinate", {
   panel_ids_df <- data.table::data.table(
     local_id = c("l1", "l2"),
     panel_id = c("p1", "p1")
@@ -12,20 +14,73 @@ test_that("make_panel_ids gives every station in a panel its most-recent-year co
   geocoded_locais <- data.table::data.table(
     local_id = c("l1", "l2", "l3"),
     ano = c(2018L, 2022L, 2020L),
-    tse_long = c(-60, -61, -62),
-    tse_lat = c(-9, -8, -7)
+    final_long = c(-60, -61, -62),
+    final_lat = c(-9, -8, -7),
+    # l1 is more accurate (smaller pred_dist) than the more recent l2.
+    pred_dist = c(0.2, 0.5, 3.0)
   )
 
   out <- make_panel_ids(copy(panel_ids_df), copy(panel_ids_states), copy(geocoded_locais))
 
   expect_equal(nrow(out), 3L)
-  expect_true(all(c("local_id", "panel_id", "long", "lat") %in% names(out)))
+  expect_true(all(c("local_id", "panel_id", "long", "lat", "pred_dist") %in% names(out)))
 
-  # Panel p1 spans 2018 (l1) and 2022 (l2); both stations take the 2022 coords.
-  expect_equal(out[local_id == "l1", long], -61)
-  expect_equal(out[local_id == "l1", lat], -8)
-  expect_equal(out[local_id == "l2", long], -61)
-  # Panel p2 has a single station and keeps its own coordinates.
+  # Panel p1 spans 2018 (l1, pred_dist 0.2) and 2022 (l2, pred_dist 0.5). The
+  # coordinate is chosen by accuracy, not recency, so both stations take l1's
+  # 2018 coordinate - NOT l2's more recent one.
+  expect_equal(out[local_id == "l1", long], -60)
+  expect_equal(out[local_id == "l1", lat], -9)
+  expect_equal(out[local_id == "l2", long], -60)
+  expect_equal(out[local_id == "l2", lat], -9)
+  expect_equal(out[local_id == "l2", pred_dist], 0.2)
+  # Panel p2 has a single station and keeps its own coordinates and pred_dist.
   expect_equal(out[local_id == "l3", long], -62)
   expect_equal(out[local_id == "l3", lat], -7)
+  expect_equal(out[local_id == "l3", pred_dist], 3.0)
+})
+
+test_that("make_panel_ids uses model coordinates when a panel has no TSE year", {
+  # Regression guard: a panel whose only coordinates come from the model (all
+  # pred_dist > 0, i.e. no TSE ground truth) must still receive a coordinate.
+  # The bug this replaced read tse_long/tse_lat only, blanking such panels.
+  panel_ids_df <- data.table::data.table(
+    local_id = c("a1", "a2"),
+    panel_id = c("pm", "pm")
+  )
+  panel_ids_states <- data.table::data.table(local_id = character(0), panel_id = character(0))
+  geocoded_locais <- data.table::data.table(
+    local_id = c("a1", "a2"),
+    ano = c(2006L, 2008L),
+    final_long = c(-50, -51),
+    final_lat = c(-10, -11),
+    pred_dist = c(1.5, 0.8)
+  )
+
+  out <- make_panel_ids(copy(panel_ids_df), copy(panel_ids_states), copy(geocoded_locais))
+
+  # Best (smallest pred_dist) is a2; both stations take it. No NA coordinates.
+  expect_equal(sum(is.na(out$long)), 0L)
+  expect_equal(out[local_id == "a1", long], -51)
+  expect_equal(out[local_id == "a2", lat], -11)
+})
+
+test_that("make_panel_ids leaves a panel uncoordinated only when every year is ungeocoded", {
+  # The one legitimate NA case: a panel whose every station failed to geocode.
+  panel_ids_df <- data.table::data.table(
+    local_id = c("n1", "n2"),
+    panel_id = c("pn", "pn")
+  )
+  panel_ids_states <- data.table::data.table(local_id = character(0), panel_id = character(0))
+  geocoded_locais <- data.table::data.table(
+    local_id = c("n1", "n2"),
+    ano = c(2010L, 2012L),
+    final_long = c(NA_real_, NA_real_),
+    final_lat = c(NA_real_, NA_real_),
+    pred_dist = c(NA_real_, NA_real_)
+  )
+
+  out <- make_panel_ids(copy(panel_ids_df), copy(panel_ids_states), copy(geocoded_locais))
+
+  expect_true(all(is.na(out$long)))
+  expect_true(all(is.na(out$lat)))
 })

--- a/tests/testthat/test-to_geocoded_export_schema.R
+++ b/tests/testthat/test-to_geocoded_export_schema.R
@@ -1,0 +1,41 @@
+## Spec test for to_geocoded_export_schema() (R/utilities.R). The published
+## geocoded file must keep the 0.141 column names and order - the recommended
+## coordinate ships as long/lat, NOT the internal final_long/final_lat - so
+## downstream code that read the 0.141 release keeps working.
+
+test_that("to_geocoded_export_schema renames final_* to long/lat in 0.141 order", {
+  internal <- data.table::data.table(
+    # Deliberately in a different order than the export schema, with the internal
+    # final_long/final_lat names, to prove the function renames AND reorders.
+    cd_localidade_tse = 1L,
+    ano = 2024L,
+    local_id = 1L,
+    nr_zona = 1L,
+    nr_locvot = 1L,
+    nr_cep = 1L,
+    sg_uf = "AC",
+    nm_localidade = "X",
+    nm_locvot = "Y",
+    ds_endereco = "Z",
+    ds_bairro = "W",
+    cod_localidade_ibge = 1L,
+    pred_long = -67,
+    pred_lat = -9,
+    pred_dist = 0,
+    tse_lat = -9,
+    tse_long = -67,
+    final_long = -67,
+    final_lat = -9
+  )
+
+  out <- to_geocoded_export_schema(internal)
+
+  # Exact published schema: 0.141 names (long/lat) in 0.141 order.
+  expect_identical(names(out), GEOCODED_EXPORT_SCHEMA)
+  expect_false(any(c("final_long", "final_lat") %in% names(out)))
+  expect_equal(out$long, -67)
+  expect_equal(out$lat, -9)
+
+  # Pure: the input table is not mutated.
+  expect_true("final_long" %in% names(internal))
+})

--- a/tests/testthat/test-validate_panel_release.R
+++ b/tests/testthat/test-validate_panel_release.R
@@ -1,0 +1,48 @@
+## Spec tests for validate_panel_release() (R/validation.R), the fail-loud gate
+## on the panel-id output (panel_ids.csv.gz). It exists to catch the regression
+## where make_panel_ids() stopped consulting model coordinates and left ~13% of
+## panels blank (and dropped pred_dist). Each gate must stop() loudly.
+
+make_panel_fixture <- function(n = 1000L) {
+  data.table::data.table(
+    panel_id = seq_len(n),
+    local_id = seq_len(n),
+    long = -60,
+    lat = -9,
+    pred_dist = 0.1
+  )
+}
+
+test_that("panel gates pass on a well-formed panel file", {
+  res <- validate_panel_release(make_panel_fixture())
+  expect_true(res$passed)
+  expect_length(res$failures, 0)
+  expect_equal(res$coord_na_pct, 0)
+})
+
+test_that("Gate P1 fails when pred_dist is dropped", {
+  p <- make_panel_fixture()
+  p[, pred_dist := NULL]
+  expect_error(validate_panel_release(p), "Gate P1.*pred_dist")
+})
+
+test_that("Gate P2 fails when too many panels lack a coordinate", {
+  # Blank 13% of coordinates - the exact regression this gate guards against.
+  p <- make_panel_fixture(1000L)
+  p[seq_len(130L), c("long", "lat") := NA_real_]
+  expect_error(validate_panel_release(p), "Gate P2.*ignoring model coordinates")
+})
+
+test_that("Gate P2 tolerates a tiny rate of genuinely ungeocoded panels", {
+  # A handful of panels whose every year failed to geocode is legitimate.
+  p <- make_panel_fixture(1000L)
+  p[1L, c("long", "lat") := NA_real_]
+  res <- validate_panel_release(p)
+  expect_true(res$passed)
+})
+
+test_that("Gate P2 fails when long/lat columns are missing entirely", {
+  p <- make_panel_fixture()
+  p[, c("long", "lat") := NULL]
+  expect_error(validate_panel_release(p), "Gate P2.*missing long/lat")
+})

--- a/tests/testthat/test-validate_release_gates.R
+++ b/tests/testthat/test-validate_release_gates.R
@@ -204,6 +204,17 @@ test_that("Gate 5 (absolute counts) is enforced only in production mode", {
   )
 })
 
+test_that("Gate 8 fails when a TSE-covered row has non-zero pred_dist", {
+  # TSE-covered stations ship the ground-truth coordinate, so pred_dist must be
+  # 0. A non-zero value is the finalize_coords regression this gate guards.
+  g <- make_geocoded_fixture()
+  g[ano == 2020L & tse_long == -67.8, pred_dist := 0.05]
+  expect_error(
+    validate_release_gates(g, make_coverage_fixture(), make_raw_avail_fixture(), make_export_paths(), dev_mode = TRUE),
+    "Gate 8.*pred_dist"
+  )
+})
+
 test_that("Gate 5 catches an exploded non-2024 year in production mode", {
   # Build a fixture at plausible national scale so only the exploded year trips.
   years <- seq(2006L, 2024L, by = 2L)


### PR DESCRIPTION
## What this PR is for

When the pipeline was reorganized, a few things about the two published files quietly changed in ways nobody intended. This PR restores the intended behavior and adds automatic checks so the same kind of silent breakage can't happen again. The goal is that v0.15 is a clean, drop-in replacement for the previous release (0.141): same file layout, correct coordinates everywhere they should be.

## The problems fixed

1. **The panel file was missing coordinates.** `panel_ids.csv.gz` links a polling station across elections and gives each one a single coordinate. The reorganization made it read only the official (TSE) coordinates and ignore the model's coordinates entirely, so any station whose elections all predate the TSE data (which starts in 2018) came out blank — **12.8% of the file (117,375 rows) had no coordinate**, versus **0%** in the previous release. It also dropped the `pred_dist` accuracy column. Root cause was two-fold: the function read the wrong coordinate columns, *and* the pipeline fed it the TSE-only table instead of the full geocoded output. Now: **0% missing**, `pred_dist` restored, and each panel gets its most accurate coordinate.

2. **Ground-truth stations were no longer flagged as exact.** In the main file, stations with an official TSE coordinate are supposed to have `pred_dist = 0` (they're measured, not estimated). The reorganization stopped doing this, so all 257,000 ground-truth stations carried a misleading model-error value. Restored.

3. **Column names and order drifted from 0.141.** The recommended coordinate columns had been renamed `long`/`lat` → `final_long`/`final_lat` and the columns reordered — a break for anyone whose code reads those files. This PR keeps the clearer names internally but publishes the original 0.141 names and order. **The exported geocoded header is now byte-identical to 0.141.**

## Safeguards added (so this can't silently recur)

- `panel_release_gates` target: fails the build if the panel file drops `pred_dist` or leaves more than 1% of panels without a coordinate. Wired as a dependency of the main `release_gates` check so it can't be bypassed.
- `release_gates` Gate 8: fails the build if any TSE ground-truth station has a non-zero `pred_dist`.
- `release_gates` Gate 9: validates the *published* column schema (names + 0.141 order), not just the internal table.
- Rewrote the panel test (it previously locked in the broken behavior) and added tests for the export schema mapper and the new gate.

## Verification

- Full fast test suite: 305 pass, 0 fail.
- Regenerated both outputs from this code: panel file 0% missing coordinates with `pred_dist` restored; geocoded file has all 257,339 TSE rows at `pred_dist = 0` and a header byte-identical to 0.141; all release gates pass on the production build.
- Reviewed with `/simplify` (three efficiency cleanups applied) and three rounds of Codex review (all findings resolved; final pass clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)