### PR TITLE
Cleanup phase 5: invalidation integrity (C2, H5, H9) (#36)

### DIFF
--- a/R/config.R
+++ b/R/config.R
@@ -45,28 +45,27 @@ BRAZIL_STATES <- c(
   "TO"
 )
 
-get_pipeline_config <- function(dev_mode = FALSE) {
-  # Get pipeline configuration based on development mode
+# The two smallest states by population, processed in dev mode for fast testing
+# (Acre and Roraima). Defined once and reused by both get_pipeline_config() and
+# the tracked-input file helpers below so the dev subset can never disagree.
+DEV_STATES <- c("AC", "RR")
 
-  if (dev_mode) {
-    config <- list(
-      dev_mode = TRUE,
-      dev_states = c("AC", "RR"), # Acre and Roraima - smallest states by population for fast testing
-      batch_size = 10,
-      max_workers = 2,
-      cache_dir = "_targets/cache",
-      log_level = "DEBUG"
-    )
-  } else {
-    config <- list(
-      dev_mode = FALSE,
-      dev_states = NULL, # Process all states
-      batch_size = 100,
-      max_workers = parallel::detectCores() - 1,
-      cache_dir = "_targets/cache",
-      log_level = "INFO"
-    )
-  }
+get_pipeline_config <- function(dev_mode = FALSE) {
+  # Get pipeline configuration based on development mode.
+  #
+  # This object is stored as the `pipeline_config` target, so every field it
+  # carries becomes part of that target's hash and cascades invalidation to the
+  # whole pipeline when it changes. It therefore holds ONLY machine-independent,
+  # behavior-affecting settings. Machine-derived or unused fields (max_workers /
+  # n_cores from detectCores(), batch_size, cache_dir, log_level) were dropped
+  # (cleanup phase 5, H9) so a rerun on a different machine does not needlessly
+  # recompute everything. Worker counts live in get_crew_controllers().
+
+  config <- list(
+    dev_mode = dev_mode,
+    # Process the dev subset in dev mode, all states (NULL) in production.
+    dev_states = if (dev_mode) DEV_STATES else NULL
+  )
 
   # Panel record-linkage weight threshold (Fellegi-Sunter). An explicit,
   # tracked config field replaces the former untracked
@@ -75,7 +74,6 @@ get_pipeline_config <- function(dev_mode = FALSE) {
   config$panel_weight_threshold <- 0
 
   # Add computed values
-  config$n_cores <- config$max_workers
   config$states <- if (is.null(config$dev_states)) {
     BRAZIL_STATES
   } else {
@@ -85,52 +83,51 @@ get_pipeline_config <- function(dev_mode = FALSE) {
   return(config)
 }
 
-get_states_for_processing <- function(context, pipeline_config, custom_states = NULL) {
-  # Get states to process based on context and mode
-  # Centralized function to determine which states to process based on the
-  # pipeline context and development mode setting
+# ===== TRACKED INPUT FILE ENUMERATION =====
+# These helpers list the real input files on disk at pipeline-definition time so
+# tar_files_input() can track each file's content (cleanup phase 5, C2). They are
+# evaluated when _targets.R is sourced -- once per tar_make() -- and take the
+# dev_mode flag directly (not the pipeline_config target) because tar_files_input
+# needs its file vector before any target has run. They fail loud if a directory
+# yields no matching files, so a missing/misnamed input surfaces at definition
+# time instead of silently producing an empty branch set.
 
-  if (pipeline_config$dev_mode) {
-    return(pipeline_config$dev_states)
+get_cnefe_state_files <- function(year, dev_mode = FALSE, dev_states = DEV_STATES) {
+  # Per-state CNEFE .csv.gz paths for the given year (2010 or 2022), restricted
+  # to the dev subset in dev mode. One tracked branch per returned file.
+  dir <- file.path("data", paste0("cnefe_", year))
+  pattern <- paste0("^cnefe_", year, "_.*\\.csv\\.gz$")
+  files <- list.files(dir, pattern = pattern, full.names = TRUE)
+  if (dev_mode) {
+    states <- sub(paste0("^cnefe_", year, "_(.+)\\.csv\\.gz$"), "\\1", basename(files))
+    files <- files[states %in% dev_states]
   }
-
-  # Production mode - determine states based on context
-  switch(
-    context,
-    cnefe10 = {
-      state_files <- list.files("data/cnefe_2010", pattern = "cnefe_2010_.*\\.csv\\.gz$")
-      gsub("cnefe_2010_(.+)\\.csv\\.gz", "\\1", state_files)
-    },
-    cnefe22 = {
-      state_files <- list.files("data/cnefe_2022", pattern = "cnefe_2022_.*\\.csv\\.gz$")
-      gsub("cnefe_2022_(.+)\\.csv\\.gz", "\\1", state_files)
-    },
-    panel = {
-      # Use custom states or default to all Brazilian states
-      custom_states %||% BRAZIL_STATES
-    },
-    stop("Unknown context: ", context)
-  )
+  if (length(files) == 0L) {
+    stop(sprintf("No CNEFE %d state files found under %s/", year, dir))
+  }
+  sort(files)
 }
 
-get_agro_cnefe_files <- function(pipeline_config) {
-  # Get agro CNEFE files based on mode
-  # Special handler for agro_cnefe_files which returns file paths not states
-  # In dev mode, maps state abbreviations to specific file names
-  # In production mode, returns all files in the agro_censo directory
-
-  if (pipeline_config$dev_mode) {
+get_agro_cnefe_files <- function(dev_mode = FALSE, dev_states = DEV_STATES) {
+  # 2017 agro-CNEFE state file paths, restricted to the dev subset in dev mode.
+  # Source files are named by IBGE UF code + name (e.g. "12_ACRE.csv.gz"), so the
+  # dev subset maps state abbreviations to those filenames.
+  if (dev_mode) {
     state_file_map <- c(
       "AC" = "12_ACRE.csv.gz",
       "RR" = "14_RORAIMA.csv.gz",
       "AP" = "16_AMAPA.csv.gz",
       "RO" = "11_RONDONIA.csv.gz"
     )
-    dev_files <- state_file_map[pipeline_config$dev_states]
-    file.path("data/agro_censo", dev_files[!is.na(dev_files)])
+    dev_files <- state_file_map[dev_states]
+    files <- file.path("data/agro_censo", dev_files[!is.na(dev_files)])
   } else {
-    dir("data/agro_censo/", full.names = TRUE)
+    files <- list.files("data/agro_censo", pattern = "\\.csv\\.gz$", full.names = TRUE)
   }
+  if (length(files) == 0L) {
+    stop("No agro-CNEFE files found under data/agro_censo/")
+  }
+  sort(files)
 }
 
 # ===== EXPECTED MUNICIPALITY COUNTS =====

--- a/R/config.R
+++ b/R/config.R
@@ -101,7 +101,19 @@ get_cnefe_state_files <- function(year, dev_mode = FALSE, dev_states = DEV_STATE
   pattern <- paste0("^cnefe_", year, "_.*\\.csv\\.gz$")
   files <- list.files(dir, pattern = pattern, full.names = TRUE)
   if (dev_mode) {
-    files <- files[cnefe_state_from_file(files, year) %in% dev_states]
+    states <- cnefe_state_from_file(files, year)
+    # Fail loud if a requested dev state has no file on disk: silently dropping
+    # it would run a partial dev pipeline that looks complete (Codex triage).
+    missing <- setdiff(dev_states, states)
+    if (length(missing) > 0L) {
+      stop(sprintf(
+        "Missing CNEFE %d file(s) for dev state(s): %s (under %s/)",
+        year,
+        paste(missing, collapse = ", "),
+        dir
+      ))
+    }
+    files <- files[states %in% dev_states]
   }
   if (length(files) == 0L) {
     stop(sprintf("No CNEFE %d state files found under %s/", year, dir))
@@ -127,7 +139,17 @@ get_agro_cnefe_files <- function(dev_mode = FALSE, dev_states = DEV_STATES) {
         paste(missing, collapse = ", ")
       )
     }
-    files <- files[basename(files) %in% state_file_map[dev_states]]
+    wanted <- state_file_map[dev_states]
+    # Fail loud if a mapped dev file is absent on disk: silently dropping it
+    # would run a partial dev pipeline that looks complete (Codex triage).
+    absent <- setdiff(wanted, basename(files))
+    if (length(absent) > 0L) {
+      stop(
+        "Missing agro-CNEFE file(s) for dev run under data/agro_censo/: ",
+        paste(absent, collapse = ", ")
+      )
+    }
+    files <- files[basename(files) %in% wanted]
   }
   if (length(files) == 0L) {
     stop("No agro-CNEFE files found under data/agro_censo/")

--- a/R/config.R
+++ b/R/config.R
@@ -73,13 +73,6 @@ get_pipeline_config <- function(dev_mode = FALSE) {
   # Kept at 0; whether ~0.5 is intended is an evaluation question (ticket #25).
   config$panel_weight_threshold <- 0
 
-  # Add computed values
-  config$states <- if (is.null(config$dev_states)) {
-    BRAZIL_STATES
-  } else {
-    config$dev_states
-  }
-
   return(config)
 }
 
@@ -92,6 +85,15 @@ get_pipeline_config <- function(dev_mode = FALSE) {
 # yields no matching files, so a missing/misnamed input surfaces at definition
 # time instead of silently producing an empty branch set.
 
+cnefe_state_from_file <- function(file, year) {
+  # Extract the state abbreviation from a CNEFE filename, e.g.
+  # "cnefe_2010_AC.csv.gz" -> "AC". The naming convention
+  # cnefe_<year>_<STATE>.csv.gz is encoded here as the single source of truth so
+  # get_cnefe_state_files() (dev filtering) and process_cnefe_state() (per-branch
+  # state derivation) cannot drift apart.
+  sub(paste0("^cnefe_", year, "_(.+)\\.csv\\.gz$"), "\\1", basename(file))
+}
+
 get_cnefe_state_files <- function(year, dev_mode = FALSE, dev_states = DEV_STATES) {
   # Per-state CNEFE .csv.gz paths for the given year (2010 or 2022), restricted
   # to the dev subset in dev mode. One tracked branch per returned file.
@@ -99,8 +101,7 @@ get_cnefe_state_files <- function(year, dev_mode = FALSE, dev_states = DEV_STATE
   pattern <- paste0("^cnefe_", year, "_.*\\.csv\\.gz$")
   files <- list.files(dir, pattern = pattern, full.names = TRUE)
   if (dev_mode) {
-    states <- sub(paste0("^cnefe_", year, "_(.+)\\.csv\\.gz$"), "\\1", basename(files))
-    files <- files[states %in% dev_states]
+    files <- files[cnefe_state_from_file(files, year) %in% dev_states]
   }
   if (length(files) == 0L) {
     stop(sprintf("No CNEFE %d state files found under %s/", year, dir))
@@ -110,19 +111,23 @@ get_cnefe_state_files <- function(year, dev_mode = FALSE, dev_states = DEV_STATE
 
 get_agro_cnefe_files <- function(dev_mode = FALSE, dev_states = DEV_STATES) {
   # 2017 agro-CNEFE state file paths, restricted to the dev subset in dev mode.
-  # Source files are named by IBGE UF code + name (e.g. "12_ACRE.csv.gz"), so the
-  # dev subset maps state abbreviations to those filenames.
+  # Always glob the directory (single source for the file list); dev mode then
+  # filters that list. Agro filenames encode the IBGE UF code + name (e.g.
+  # "12_ACRE.csv.gz"), not the state abbreviation, so the dev filter needs an
+  # explicit abbreviation -> filename map. A fail-loud guard requires every
+  # dev_states entry to appear in the map, so the map can never silently drift
+  # from DEV_STATES.
+  files <- list.files("data/agro_censo", pattern = "\\.csv\\.gz$", full.names = TRUE)
   if (dev_mode) {
-    state_file_map <- c(
-      "AC" = "12_ACRE.csv.gz",
-      "RR" = "14_RORAIMA.csv.gz",
-      "AP" = "16_AMAPA.csv.gz",
-      "RO" = "11_RONDONIA.csv.gz"
-    )
-    dev_files <- state_file_map[dev_states]
-    files <- file.path("data/agro_censo", dev_files[!is.na(dev_files)])
-  } else {
-    files <- list.files("data/agro_censo", pattern = "\\.csv\\.gz$", full.names = TRUE)
+    state_file_map <- c("AC" = "12_ACRE.csv.gz", "RR" = "14_RORAIMA.csv.gz")
+    missing <- setdiff(dev_states, names(state_file_map))
+    if (length(missing) > 0L) {
+      stop(
+        "get_agro_cnefe_files(): no agro filename mapping for dev state(s): ",
+        paste(missing, collapse = ", ")
+      )
+    }
+    files <- files[basename(files) %in% state_file_map[dev_states]]
   }
   if (length(files) == 0L) {
     stop("No agro-CNEFE files found under data/agro_censo/")

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -168,11 +168,7 @@ process_cnefe_state <- function(state_file, year, muni_ids, tract_centroids = NU
   # "data/cnefe_2010/cnefe_2010_AC.csv.gz". Deriving the state from the filename
   # (rather than passing it separately) keeps the file content the single tracked
   # dependency, so a re-downloaded state file invalidates exactly its branch.
-  state <- sub(
-    paste0("^cnefe_", year, "_(.+)\\.csv\\.gz$"),
-    "\\1",
-    basename(state_file)
-  )
+  state <- cnefe_state_from_file(state_file, year)
 
   # Get municipality IDs for this state
   state_muni_ids <- muni_ids[estado_abrev == state]

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -163,16 +163,26 @@ apply_brasilia_filters <- function(data, remove_brasilia = TRUE, state_col = "sg
 #' @return A list with `st` (street aggregates), `bairro` (neighborhood
 #'   aggregates), and `schools` (school rows) for this state
 #' @export
-process_cnefe_state <- function(state, year, muni_ids, tract_centroids = NULL) {
-  # Construct file path
-  state_file <- file.path(
-    "data",
-    paste0("cnefe_", year),
-    paste0("cnefe_", year, "_", state, ".csv.gz")
+process_cnefe_state <- function(state_file, year, muni_ids, tract_centroids = NULL) {
+  # state_file is the tracked per-state CNEFE path (cleanup phase 5, C2), e.g.
+  # "data/cnefe_2010/cnefe_2010_AC.csv.gz". Deriving the state from the filename
+  # (rather than passing it separately) keeps the file content the single tracked
+  # dependency, so a re-downloaded state file invalidates exactly its branch.
+  state <- sub(
+    paste0("^cnefe_", year, "_(.+)\\.csv\\.gz$"),
+    "\\1",
+    basename(state_file)
   )
 
   # Get municipality IDs for this state
   state_muni_ids <- muni_ids[estado_abrev == state]
+  if (nrow(state_muni_ids) == 0L) {
+    stop(sprintf(
+      "process_cnefe_state(): no muni_ids rows for state '%s' derived from %s",
+      state,
+      state_file
+    ))
+  }
 
   if (year == 2010) {
     # Read state data

--- a/_targets.R
+++ b/_targets.R
@@ -289,40 +289,49 @@ list(
   # full cleaned address rows are never persisted (spec D5). The national
   # `cnefe10` combine and the duplicate schools read/clean pass are deleted; the
   # small aggregates are row-bound from the per-state results below.
-  tar_target(
-    name = cnefe10_states,
-    command = get_states_for_processing("cnefe10", pipeline_config)
+  # Track each 2010 CNEFE state file's content (cleanup phase 5, C2) so a
+  # re-downloaded or added file invalidates exactly its branch. tar_files_input
+  # enumerates the files at definition time via the DEV_MODE-aware helper;
+  # repository = "local" keeps file tracking off S3, matching the other input
+  # file targets.
+  tarchetypes::tar_files_input(
+    cnefe10_files,
+    get_cnefe_state_files(2010, DEV_MODE),
+    format = "file",
+    repository = "local"
   ),
   # Clean each state and aggregate in-memory (streets, neighborhoods, schools)
   tar_target(
     name = cnefe10_by_state,
     command = process_cnefe_state(
-      state = cnefe10_states,
+      state_file = cnefe10_files,
       year = 2010,
       muni_ids = muni_ids,
       tract_centroids = tract_centroids
     ),
-    pattern = map(cnefe10_states),
+    pattern = map(cnefe10_files),
     format = "qs",
     iteration = "list",
     resources = tar_resources(
       crew = tar_resources_crew(controller = "memory_limited")
     )
   ),
-  # Get list of states to process based on mode
-  tar_target(
-    name = cnefe22_states,
-    command = get_states_for_processing("cnefe22", pipeline_config)
+  # Track each 2022 CNEFE state file's content (cleanup phase 5, C2).
+  tarchetypes::tar_files_input(
+    cnefe22_files,
+    get_cnefe_state_files(2022, DEV_MODE),
+    format = "file",
+    repository = "local"
   ),
   # Clean each state and aggregate in-memory (streets, neighborhoods, schools)
   tar_target(
     name = cnefe22_by_state,
     command = process_cnefe_state(
-      state = cnefe22_states,
+      state_file = cnefe22_files,
       year = 2022,
       muni_ids = muni_ids
     ),
-    pattern = map(cnefe22_states),
+    pattern = map(cnefe22_files),
     format = "qs",
     iteration = "list",
     resources = tar_resources(
@@ -363,9 +372,14 @@ list(
     retrieval = "worker"
   ),
   ## Import and clean 2017 CNEFE
-  tar_target(
-    name = agro_cnefe_files,
-    command = get_agro_cnefe_files(pipeline_config)
+  # Track each agro-CNEFE state file's content (cleanup phase 5, C2). clean_agro_cnefe
+  # consumes the aggregated branch paths (a non-mapped consumer of a branched file
+  # target receives the full vector of paths), so a changed file rebuilds agro_cnefe.
+  tarchetypes::tar_files_input(
+    agro_cnefe_files,
+    get_agro_cnefe_files(DEV_MODE),
+    format = "file",
+    repository = "local"
   ),
   tar_target(
     name = agro_cnefe,
@@ -975,8 +989,11 @@ list(
       dir.create("output", showWarnings = FALSE)
       writeLines(report_text, "output/string_match_diagnostics.txt")
       "output/string_match_diagnostics.txt"
-    }
-    # Now a data target that returns the file path (stored in S3)
+    },
+    # Real tracked file target (cleanup phase 5, H5): if the written report is
+    # deleted, targets rebuilds it. repository = "local" matches the input files.
+    format = "file",
+    repository = "local"
   ),
 
   # ========================================
@@ -1169,18 +1186,24 @@ list(
   # DATA EXPORT
   # ========================================
 
+  # The three exports are real tracked file targets (cleanup phase 5, H5): each
+  # command writes its file and returns the path, and format = "file" makes
+  # targets rebuild it if the output file is deleted. repository = "local" keeps
+  # the outputs off S3, matching the input-file policy.
   tar_target(
     name = geocoded_export,
     command = export_geocoded_with_validation(
       geocoded_locais,
       validation_report
-    )
-    # Now a data target that returns the file path (stored in S3)
+    ),
+    format = "file",
+    repository = "local"
   ),
   tar_target(
     name = panelid_export,
-    command = export_panel_ids_with_validation(panel_ids, validation_report)
-    # Now a data target that returns the file path (stored in S3)
+    command = export_panel_ids_with_validation(panel_ids, validation_report),
+    format = "file",
+    repository = "local"
   ),
   tar_target(
     name = section_panel_export,
@@ -1188,8 +1211,9 @@ list(
       dir.create("output", showWarnings = FALSE)
       fwrite(section_panel_mapping, "output/section_panel_mapping.csv.gz")
       "output/section_panel_mapping.csv.gz"
-    }
-    # Now a data target that returns the file path (stored in S3)
+    },
+    format = "file",
+    repository = "local"
   ),
   ## Release gates: fail-loud structural tripwires on the production rebuild
   ## before it can be shipped as v0.15 (release spec, #48). Depends on the export


### PR DESCRIPTION
## What this PR is for (plain language)

The pipeline was blind to some kinds of change. If someone re-downloaded a
census input file, or deleted one of the final output files, the pipeline could
still think everything was up to date and skip the work. And because a couple of
stored settings depended on the specific machine (like its CPU count), running
the pipeline on a different computer could needlessly trigger a full
recomputation. This PR fixes all three so the pipeline rebuilds exactly what
actually changed — no more, no less.

This is Phase 5 of the code-cleanup spec (`docs/specs/2026-07-cleanup-spec.md`),
issue #36. The fourth finding in that phase (H6, a stable polling-station
identifier) already shipped with the v0.15 release, so this PR covers the
remaining three (C2, H5, H9).

## Changes

- **C2 — track the real inputs.** Each CNEFE 2010/2022 state file and each 2017
  agro-CNEFE file is now a tracked local file target via
  `tarchetypes::tar_files_input()`. The CNEFE cleaners branch (`pattern = map()`)
  over the tracked files, so a re-downloaded or added state file invalidates
  exactly its branch. `process_cnefe_state()` takes the tracked path and derives
  the state from the filename (via the new shared `cnefe_state_from_file()`
  helper). The old untracked `list.files()` logic in `get_states_for_processing()`
  is deleted.
- **H5 — exports become real file targets.** `geocoded_export`, `panelid_export`,
  `section_panel_export`, and `string_match_diagnostics_report` are now
  `format = "file", repository = "local"`, so a deleted output rebuilds instead
  of looking current.
- **H9 — machine-independent config.** Dropped the `detectCores()`-derived and
  unused fields (`max_workers`, `n_cores`, `batch_size`, `cache_dir`,
  `log_level`, plus the dead `states`) from the stored `pipeline_config` so a
  different machine's rerun doesn't cascade invalidation. Worker counts live in
  `get_crew_controllers()`.

## Sequencing note

Issue #36 was written to land *during* the 2024 release rebuild so one expensive
run served both. The v0.15 release shipped before this landed, so realizing these
changes requires **one fresh full production rebuild** (hours, 50GB+ RAM),
decoupled from a release. That was confirmed as the intended path before this
work began.

## Verification

- Full dev-mode (AC/RR) pipeline builds end-to-end: all four export file targets
  write and track their files; `release_gates`, `panel_release_gates`, and
  `data_quality_monitoring` pass.
- 305 unit tests pass. air formatting clean.
- Reviewed with `/simplify` (dead-field removal, regex de-dup, agro dev-map
  drift guard) and Codex (added fail-loud assertions when a requested dev input
  file is missing on disk).

Note: the dev integration run overwrote the local `output/*.csv.gz` files with
AC/RR data (these are not git-tracked); the production rebuild regenerates them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)