### PR TITLE
Seed git worktrees with the pipeline state they cannot check out

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR/scripts/seed-worktree.sh\"",
+            "timeout": 300
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,10 @@ codex-full.log
 
 # crew per-worker logs (issue #48 diagnostics)
 crew_logs/
+
+# git worktrees and the state the seeding script keeps in each one
+.claude/worktrees/
+.seed-worktree-stamp
+.seed-worktree-lock/
+.reflink-probe.*
+*.seed-incoming

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,37 @@ run time.
 
 For setting up this project on a new computer with AWS S3 integration, see [AWS_SETUP.md](AWS_SETUP.md).
 
+### Worktrees
+
+Start one however you like — `claude --worktree`, or `git worktree add`. Seeding is
+automatic: a `SessionStart` hook runs [scripts/seed-worktree.sh](scripts/seed-worktree.sh),
+which fills in the gitignored state a checkout cannot carry. It takes a few seconds and
+reports what it did. Running it in the main checkout does nothing.
+
+**Each worktree owns its own stores.** A branch that changes pipeline code rebuilds its
+own `_targets_dev/` rather than invalidating anyone else's.
+
+**Run dev mode in worktrees** (`TAR_PROJECT=dev`). The production profile is seeded only
+so `tar_outdated()` tells the truth — every checkout's `_targets/` points at the same S3
+prefix, so a production `tar_destroy()` from a worktree deletes objects the main checkout
+is still using.
+
+Two lists at the top of the script are maintained by hand, and a directory the pipeline
+starts writing into later has to join `SNAPSHOT_DIRS` — otherwise every target writing
+there rebuilds in every worktree, forever.
+
+- `TOPUP_DIRS` (`data/`, `renv/library`) are immutable inputs. They are **hardlinked**:
+  this filesystem is ext4 and has no reflinks, so hardlinks are what keep a worktree at
+  ~0.8GB instead of ~6.7GB. Nothing in the pipeline writes under either path. If that
+  ever changes, that directory has to move to `SNAPSHOT_DIRS`, or a worktree build will
+  write straight through the link into the main checkout.
+- `SNAPSHOT_DIRS` (`output/`, `_targets/`, `_targets_dev/`) are written by the pipeline
+  and copied for real. They are replaced as one snapshot, and only while the worktree has
+  built nothing of its own.
+
+The hook reaches a new worktree only once the script is on the branch it was cut from, so
+it has to be on `master` to apply generally.
+
 ## Paper code
 
 Research code for a paper and a public dataset — not a software product. **Machinery

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,34 +145,39 @@ For setting up this project on a new computer with AWS S3 integration, see [AWS_
 
 ### Worktrees
 
-Start one however you like — `claude --worktree`, or `git worktree add`. Seeding is
-automatic: a `SessionStart` hook runs [scripts/seed-worktree.sh](scripts/seed-worktree.sh),
-which fills in the gitignored state a checkout cannot carry. It takes a few seconds and
-reports what it did. Running it in the main checkout does nothing.
+A worktree checks out tracked files only, so it starts with all the code and none of the
+pipeline — no stores, no CNEFE/TSE downloads, no R library. Without seeding, every target
+rebuilds, including ones the branch never touched.
 
-**Each worktree owns its own stores.** A branch that changes pipeline code rebuilds its
-own `_targets_dev/` rather than invalidating anyone else's.
+[scripts/seed-worktree.sh](scripts/seed-worktree.sh) fills that in from the main checkout.
+It takes a few seconds, reports what it did and what it skipped, and does nothing when run
+in the main checkout.
 
-**Run dev mode in worktrees** (`TAR_PROJECT=dev`). The production profile is seeded only
-so `tar_outdated()` tells the truth — every checkout's `_targets/` points at the same S3
+```bash
+scripts/seed-worktree.sh
+```
+
+A `SessionStart` hook runs it automatically **in Claude Code sessions**. A worktree created
+from a terminal stays unseeded until a session opens in it, so run the command above by
+hand there. The hook also only reaches a worktree once the script is on the branch it was
+cut from — which means `master`.
+
+**Each worktree owns its stores.** A branch that changes pipeline code rebuilds its own
+`_targets_dev/` rather than invalidating anyone else's.
+
+**Run dev mode in worktrees** (`TAR_PROJECT=dev`). Production is seeded only so
+`tar_outdated()` tells the truth: every checkout's `_targets/` points at the same S3
 prefix, so a production `tar_destroy()` from a worktree deletes objects the main checkout
 is still using.
 
-Two lists at the top of the script are maintained by hand, and a directory the pipeline
-starts writing into later has to join `SNAPSHOT_DIRS` — otherwise every target writing
+**The seed lists are maintained by hand**, at the top of the script, and the rules for
+editing them are documented there. The one worth knowing from outside: a directory the
+pipeline starts writing into later has to join `SNAPSHOT_DIRS`, or every target writing
 there rebuilds in every worktree, forever.
 
-- `TOPUP_DIRS` (`data/`, `renv/library`) are immutable inputs. They are **hardlinked**:
-  this filesystem is ext4 and has no reflinks, so hardlinks are what keep a worktree at
-  ~0.8GB instead of ~6.7GB. Nothing in the pipeline writes under either path. If that
-  ever changes, that directory has to move to `SNAPSHOT_DIRS`, or a worktree build will
-  write straight through the link into the main checkout.
-- `SNAPSHOT_DIRS` (`output/`, `_targets/`, `_targets_dev/`) are written by the pipeline
-  and copied for real. They are replaced as one snapshot, and only while the worktree has
-  built nothing of its own.
-
-The hook reaches a new worktree only once the script is on the branch it was cut from, so
-it has to be on `master` to apply generally.
+Inputs are hardlinked rather than copied, which is what keeps a worktree at ~0.8GB instead
+of ~6.7GB on this filesystem — so nothing in `TOPUP_DIRS` may ever be written by the
+pipeline, or the build would write through the link into the main checkout.
 
 ## Paper code
 

--- a/scripts/seed-worktree.sh
+++ b/scripts/seed-worktree.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+#
+# Seed a git worktree with the large, gitignored data the targets pipeline needs.
+#
+# A worktree is a checkout of tracked files only, so a new one has all the code
+# and none of the data. Copying it from the main checkout gives every worktree a
+# fully writable copy of the pipeline state, and that isolation is the point: a
+# branch that changes pipeline code rewrites its own store rather than
+# invalidating the main checkout's or colliding with a build running there.
+#
+# This repo lives on ext4, which has no reflinks, so a copy here is real bytes.
+# The two seed lists are therefore moved differently:
+#
+#   * Immutable inputs (data/, renv/library) are hardlinked. Nothing in the
+#     pipeline writes under either path — data/ holds hand-downloaded CNEFE and
+#     TSE extracts, and renv replaces a package directory rather than editing
+#     files inside it — so one inode can serve every checkout, and 6GB of inputs
+#     cost nothing per worktree. They are also topped up file by file every
+#     session and never overwritten: without that, a reused worktree quietly
+#     lacks downloads the main checkout has and the pipeline refetches them.
+#   * The stores and the output they index are copied byte for byte, because the
+#     pipeline does write there. They also have to stay one coherent snapshot —
+#     merging newer objects into an existing store would leave meta/ and
+#     objects/ disagreeing — so they are cloned whole or left alone, and
+#     re-cloned only while the worktree has built nothing of its own.
+#
+# Running this in the main checkout does nothing. It is safe to re-run, and it
+# reports what it skipped as well as what it seeded.
+#
+# A half-copied seed is the failure worth designing against, because it is the
+# one that hides: a store missing part of itself still looks seeded, so every
+# later session leaves it alone and the worktree stays broken. Two defences,
+# below — one lock so two runs cannot copy over each other, and a staging
+# directory so a copy becomes visible only once it is whole.
+
+set -euo pipefail
+
+# The store that keys the freshness stamp. Worktree sessions build in dev mode
+# (TAR_PROJECT=dev), so the dev store is the one whose contents say whether this
+# worktree has built anything of its own.
+TARGETS_STORE="_targets_dev"
+
+# Gitignored directories holding immutable inputs, as repo-relative paths
+# separated by spaces. Topped up per file, every session.
+#
+# renv/library is mostly symlinks into the shared renv cache under ~/.cache, so
+# seeding it is nearly free — but a worktree without it has no R packages at
+# all, and renv::restore() does not work in this project.
+TOPUP_DIRS="data renv/library"
+
+# Gitignored directories the pipeline writes, cloned together as one snapshot.
+# The stores belong here, alongside every directory their file targets point at
+# — miss one and each target writing there is rebuilt in the worktree whatever
+# the branch touched, because its file is simply absent.
+#
+# _targets (production) is only its metadata: the objects live in S3, so it costs
+# ~2MB. It is seeded so tar_outdated() tells the truth, not so worktrees can run
+# production — see CLAUDE.md.
+#
+# Order matters: the stamped store goes last. It is what every later run compares
+# against, so a run killed partway leaves a store still matching the stamp,
+# which is what makes the next run re-clone rather than call the mixture seeded.
+SNAPSHOT_DIRS="output _targets $TARGETS_STORE"
+
+repo_root=$(git rev-parse --show-toplevel)
+
+# The first entry of `git worktree list` is always the main checkout, which owns
+# the data everything else is seeded from.
+main_root=$(git worktree list --porcelain | sed -n '1s/^worktree //p')
+
+if [ "$repo_root" = "$main_root" ]; then
+  exit 0
+fi
+
+# The store's metadata file changes when a target is built and at no other time,
+# so comparing copies of it says which build a store is carrying. The stamp is
+# the copy this worktree was handed when it was last seeded: while the worktree's
+# own store still matches it, nothing has been built here and the snapshot is
+# disposable.
+store_meta="$TARGETS_STORE/meta/meta"
+stamp_file="$repo_root/.seed-worktree-stamp"
+
+# Opening a workspace can start this script more than once at the same moment —
+# a workspace tool's setup command and the agent's session hook both run it.
+# Since the copy paths replace whole directories, two overlapping runs delete
+# what each other is copying. Serialise on a lock directory, which mkdir creates
+# atomically or not at all. A second run has nothing to gain by waiting, since
+# the run holding the lock does its work for it.
+lock_dir="$repo_root/.seed-worktree-lock"
+staged_dirs=()
+probe=""
+probe_dir=""
+
+cleanup() {
+  rm -rf "$lock_dir"
+  [ -n "$probe" ] && rm -f "$probe"
+  [ -n "$probe_dir" ] && rm -rf "$probe_dir"
+  if [ ${#staged_dirs[@]} -gt 0 ]; then
+    rm -rf "${staged_dirs[@]}"
+  fi
+}
+
+if ! mkdir "$lock_dir" 2>/dev/null; then
+  holder=$(cat "$lock_dir/pid" 2>/dev/null || true)
+  if [ -z "$holder" ]; then
+    # The holder creates the lock and then writes its pid into it, so an empty
+    # lock usually means it is mid-way between the two. Give it a moment before
+    # concluding anything: treating that instant as an abandoned lock is exactly
+    # how two runs would end up copying at once.
+    sleep 1
+    holder=$(cat "$lock_dir/pid" 2>/dev/null || true)
+  fi
+  if [ -n "$holder" ] && kill -0 "$holder" 2>/dev/null; then
+    # Pids are recycled, so this can in principle name something else entirely.
+    # Say where the lock is, so a wedged worktree is one deletion from working.
+    echo "seed-worktree: another seed (pid $holder) is running here; leaving it to finish."
+    echo "seed-worktree: if none is, remove $lock_dir and re-run."
+    exit 0
+  fi
+  # Nobody holds it: a previous run was killed — a session hook that outran its
+  # timeout, most likely. It staged its copies rather than writing them in
+  # place, so nothing here is half-replaced and the lock is safe to take over.
+  # Claim it by renaming, which only one taker-over can win.
+  stale_lock="$lock_dir.stale.$$"
+  if ! mv "$lock_dir" "$stale_lock" 2>/dev/null; then
+    echo "seed-worktree: another seed is claiming the lock here; leaving it to finish."
+    exit 0
+  fi
+  rm -rf "$stale_lock"
+  if ! mkdir "$lock_dir" 2>/dev/null; then
+    echo "seed-worktree: another seed is claiming the lock here; leaving it to finish."
+    exit 0
+  fi
+  echo "seed-worktree: took over a lock left by pid ${holder:-unknown}, which is no longer running." >&2
+fi
+trap cleanup EXIT
+echo $$ > "$lock_dir/pid"
+
+# A directory counts as seeded once it holds gitignored content — the pipeline
+# bulk. Tracked files inside it (a .gitkeep placeholder, a README, a codebook)
+# arrive with the checkout and say nothing about whether the data is here, and
+# --no-empty-directory keeps an empty one from passing for the data either.
+holds_ignored_content() {
+  local root=$1 rel=$2
+  [ -n "$(git -C "$root" ls-files --others --ignored --exclude-standard --directory --no-empty-directory -- "$rel")" ]
+}
+
+# Whether a checkout's snapshot is whole, which is a stronger question than
+# whether it holds something. A store whose objects arrived but whose meta/ did
+# not is a directory full of gigabytes that targets reads as an empty store,
+# and "it holds content" says it is seeded, forever.
+snapshot_is_whole() {
+  local root=$1 rel
+  for rel in $SNAPSHOT_DIRS; do
+    holds_ignored_content "$root" "$rel" || return 1
+  done
+  [ -f "$root/$store_meta" ]
+}
+
+for rel in $TOPUP_DIRS $SNAPSHOT_DIRS; do
+  case "$rel" in
+    /* | *..*)
+      echo "seed-worktree: seed directories take repo-relative paths; got '$rel'." >&2
+      exit 1
+      ;;
+  esac
+  if [ ! -d "$main_root/$rel" ]; then
+    echo "seed-worktree: the main checkout has no directory at $rel; fix the seed lists at the top of this script." >&2
+    exit 1
+  fi
+done
+
+# Whether this worktree holds builds of its own. The stamp is the store it was
+# handed; the main checkout's is the store it would be handed now. A store
+# matching either holds nothing that re-cloning would not reproduce — anything
+# else was built here, and is not this script's to replace.
+worktree_has_built() {
+  [ -f "$repo_root/$store_meta" ] &&
+    ! cmp -s "$repo_root/$store_meta" "$stamp_file" &&
+    ! cmp -s "$repo_root/$store_meta" "$main_root/$store_meta"
+}
+
+worktree_whole=true
+snapshot_is_whole "$repo_root" || worktree_whole=false
+
+snapshot_action="keep"
+if worktree_has_built; then
+  snapshot_note="left alone; it holds builds of its own, so delete these here and re-run to take the main checkout's"
+  # An incomplete snapshot that also holds local builds is the one case with no
+  # safe automatic answer: re-cloning would throw the builds away. Name what is
+  # missing and leave the choice to whoever is here. This is what a directory
+  # newly added to SNAPSHOT_DIRS looks like in a worktree that predates it.
+  if [ "$worktree_whole" = false ]; then
+    echo "seed-worktree: part of the snapshot here is missing — each of $SNAPSHOT_DIRS should hold data, and the store needs $store_meta." >&2
+    echo "seed-worktree: leaving it alone, because this worktree has built its own store. Until the gap is filled by hand or the whole snapshot replaced, targets rebuilds everything that writes to the missing directory." >&2
+  fi
+elif [ "$worktree_whole" = true ] && cmp -s "$repo_root/$store_meta" "$main_root/$store_meta"; then
+  snapshot_note="in step with the main checkout"
+else
+  snapshot_action="clone"
+  if [ ! -d "$repo_root/$TARGETS_STORE" ]; then
+    snapshot_note="cloned from the main checkout"
+  elif [ "$worktree_whole" = false ]; then
+    snapshot_note="re-cloned: part of it was missing, so an earlier copy had stopped short"
+  else
+    snapshot_note="re-cloned: nothing had been built here and the main checkout's store had moved on"
+  fi
+fi
+
+if [ "$snapshot_action" = "clone" ]; then
+  # Confirm the source before touching anything, so a main checkout that has
+  # never built stops the run instead of leaving the worktree with an empty store.
+  if ! snapshot_is_whole "$main_root"; then
+    echo "seed-worktree: the main checkout has no whole snapshot to seed from: it needs gitignored content in $SNAPSHOT_DIRS, and a store at $store_meta." >&2
+    echo "seed-worktree: build the pipeline there first." >&2
+    exit 1
+  fi
+
+  # targets records the pid of the process that last wrote a store, and the
+  # record outlives the build. Both stores are checked, since either can be mid
+  # build while the other is idle. Confirm the pid still belongs to an R process
+  # before believing it: pids get recycled, and a stale one owned by something
+  # unrelated would block every session from here on.
+  for rel in $SNAPSHOT_DIRS; do
+    process_file="$main_root/$rel/meta/process"
+    [ -f "$process_file" ] || continue
+    builder_pid=$(sed -n 's/^pid|//p' "$process_file")
+    if [ -n "$builder_pid" ] && ps -o comm= -p "$builder_pid" 2>/dev/null | grep -qiE '(^|/)r(script)?$'; then
+      echo "seed-worktree: a targets pipeline (pid $builder_pid) is writing the main checkout's $rel." >&2
+      echo "seed-worktree: re-run once it finishes, so the worktree gets a whole snapshot." >&2
+      exit 1
+    fi
+  done
+fi
+
+# Every file the main checkout has and this worktree lacks. Existing files are
+# never touched: the inputs are immutable, so a file already here is the file
+# that belongs here.
+#
+# Symlinks count as files to seed. Most of renv/library is symlinks into the
+# shared renv cache under an absolute path outside the repo, so they resolve
+# identically from a worktree — but -type f alone would skip all of them and
+# leave the library a shell of empty directories.
+topup_src=()
+topup_dest=()
+topup_total=0
+for rel in $TOPUP_DIRS; do
+  while IFS= read -r -d '' src; do
+    topup_total=$((topup_total + 1))
+    dest="$repo_root/$rel/${src#"$main_root/$rel/"}"
+    # -L as well as -e, so an existing symlink counts as present even when what
+    # it points at has gone.
+    if [ ! -e "$dest" ] && [ ! -L "$dest" ]; then
+      topup_src+=("$src")
+      topup_dest+=("$dest")
+    fi
+  done < <(find "$main_root/$rel" \( -type f -o -type l \) -print0)
+done
+topup_count=${#topup_src[@]}
+
+# A cloud-sync client sees a seeded worktree as gigabytes of new files to upload,
+# all of it reproducible from git plus the main checkout. Mark the worktree
+# before copying into it, so the client never starts indexing the seed. Dropbox
+# honours this attribute; on iCloud Drive or OneDrive, keep worktrees outside the
+# synced folder instead.
+if command -v xattr >/dev/null 2>&1; then
+  case "$repo_root" in
+    *Dropbox*)
+      xattr -w com.dropbox.ignored 1 "$repo_root"
+      if [ -d "$main_root/.claude/worktrees" ]; then
+        xattr -w com.dropbox.ignored 1 "$main_root/.claude/worktrees"
+      fi
+      ;;
+  esac
+fi
+
+if [ "$snapshot_action" = "clone" ] || [ "$topup_count" -gt 0 ]; then
+  # Probe both copy modes with a scratch file along the real copy path, main
+  # checkout to worktree, so a cross-volume worktree fails the probe rather than
+  # the multi-gigabyte copy.
+  probe=$(mktemp "$main_root/.reflink-probe.XXXXXX")
+  probe_dir=$(mktemp -d "$repo_root/.reflink-probe.XXXXXX")
+
+  # Reflink flags differ by platform: -c is APFS/macOS, --reflink=always is GNU
+  # cp on Btrfs or XFS. ext4 has neither, which is why the inputs are hardlinked
+  # rather than cloned; keep the probe so a move to Btrfs is picked up for free.
+  clone_flag=""
+  if cp -c "$probe" "$probe_dir/out" 2>/dev/null; then
+    clone_flag="-c"
+  elif cp --reflink=always "$probe" "$probe_dir/out" 2>/dev/null; then
+    clone_flag="--reflink=always"
+  fi
+  rm -f "$probe_dir/out"
+
+  # Hardlinks need one filesystem, same as reflinks, so a worktree on another
+  # volume falls back to whatever the snapshot copy uses.
+  link_flag="-l"
+  if ! cp -l "$probe" "$probe_dir/out" 2>/dev/null; then
+    link_flag="$clone_flag"
+    echo "seed-worktree: hardlinks do not reach this worktree, so the inputs are copied instead; expect it to be slow and to consume disk." >&2
+  fi
+  rm -f "$probe_dir/out"
+
+  # -p keeps mtimes, which targets uses to skip re-hashing the store. macOS
+  # clonefile preserves them regardless; the other two paths do not.
+  #
+  # Each directory is copied to a staging path beside its destination and moved
+  # into place only once the copy has returned, so an interrupted run leaves
+  # nothing a later run could read as a seeded snapshot. Staging beside the
+  # destination keeps the move a rename within one filesystem.
+  if [ "$snapshot_action" = "clone" ]; then
+    for rel in $SNAPSHOT_DIRS; do
+      staging="$repo_root/$rel.seed-incoming"
+      rm -rf "$staging"
+      staged_dirs+=("$staging")
+      cp $clone_flag -Rp "$main_root/$rel" "$staging"
+      rm -rf "${repo_root:?}/$rel"
+      mv "$staging" "$repo_root/$rel"
+    done
+    cp $clone_flag -p "$main_root/$store_meta" "$stamp_file"
+  fi
+
+  for ((i = 0; i < topup_count; i++)); do
+    mkdir -p "$(dirname "${topup_dest[$i]}")"
+    if [ -L "${topup_src[$i]}" ]; then
+      cp -P "${topup_src[$i]}" "${topup_dest[$i]}"
+    else
+      cp $link_flag -p "${topup_src[$i]}" "${topup_dest[$i]}"
+    fi
+  done
+fi
+
+if [ "$topup_count" -gt 0 ]; then
+  echo "seed-worktree: $TOPUP_DIRS: added $topup_count of $topup_total files from the main checkout."
+else
+  echo "seed-worktree: $TOPUP_DIRS: complete ($topup_total files)."
+fi
+echo "seed-worktree: $SNAPSHOT_DIRS: $snapshot_note."

--- a/scripts/seed-worktree.sh
+++ b/scripts/seed-worktree.sh
@@ -59,11 +59,16 @@ TOPUP_DIRS="data renv/library"
 # what makes the next run re-clone rather than call the mixture seeded.
 SNAPSHOT_DIRS="output reports $STORE_DIRS"
 
-repo_root=$(git rev-parse --show-toplevel)
+# The checkout to seed is the one holding this script, not the one the caller
+# happens to be standing in. Resolving from the working directory instead would
+# make `path/to/a/worktree/scripts/seed-worktree.sh`, run from anywhere else,
+# exit silently as a no-op and look like it had seeded.
+script_dir=$(cd "$(dirname "$0")" && pwd)
+repo_root=$(git -C "$script_dir" rev-parse --show-toplevel)
 
 # The first entry of `git worktree list` is always the main checkout, which owns
 # the data everything else is seeded from.
-main_root=$(git worktree list --porcelain | sed -n '1s/^worktree //p')
+main_root=$(git -C "$script_dir" worktree list --porcelain | sed -n '1s/^worktree //p')
 
 if [ "$repo_root" = "$main_root" ]; then
   exit 0

--- a/scripts/seed-worktree.sh
+++ b/scripts/seed-worktree.sh
@@ -356,6 +356,16 @@ if [ "$snapshot_action" = "clone" ] || [ "$topup_count" -gt 0 ]; then
         cp -p "$repo_root/$tracked" "$staged_file"
       done < <(git -C "$repo_root" ls-files -z -- "$rel")
 
+      # The other direction: a file the branch deleted or renamed is still
+      # tracked in the main checkout, so the staged copy would reappear here as
+      # untracked litter. Being absent from this worktree's index is what
+      # separates a branch deletion from a file merely missing off disk.
+      while IFS= read -r -d '' tracked; do
+        if ! git -C "$repo_root" ls-files --error-unmatch -- "$tracked" >/dev/null 2>&1; then
+          rm -f "$staged/${tracked#"$rel/"}"
+        fi
+      done < <(git -C "$main_root" ls-files -z -- "$rel")
+
       rm -rf "${repo_root:?}/$rel"
       mv "$staged" "$repo_root/$rel"
       staged=""

--- a/scripts/seed-worktree.sh
+++ b/scripts/seed-worktree.sh
@@ -24,21 +24,21 @@
 #     objects/ disagreeing — so they are cloned whole or left alone, and
 #     re-cloned only while the worktree has built nothing of its own.
 #
-# Running this in the main checkout does nothing. It is safe to re-run, and it
-# reports what it skipped as well as what it seeded.
-#
-# A half-copied seed is the failure worth designing against, because it is the
+# The failure worth designing against is a half-copied seed, because it is the
 # one that hides: a store missing part of itself still looks seeded, so every
-# later session leaves it alone and the worktree stays broken. Two defences,
-# below — one lock so two runs cannot copy over each other, and a staging
-# directory so a copy becomes visible only once it is whole.
+# later session leaves it alone and the worktree stays broken for as long as it
+# lives. The lock and the staging directory below are the two defences.
 
 set -euo pipefail
 
-# The store that keys the freshness stamp. Worktree sessions build in dev mode
-# (TAR_PROJECT=dev), so the dev store is the one whose contents say whether this
-# worktree has built anything of its own.
-TARGETS_STORE="_targets_dev"
+# The two targets stores, whose paths are declared in _targets.yaml: _targets is
+# the production profile, _targets_dev the AC/RR dev profile. Rename one there
+# and it has to be renamed here too — nothing ties the two files together.
+#
+# _targets is only its metadata, since the objects live in S3, so it costs ~2MB.
+# It is seeded so tar_outdated() tells the truth, not so worktrees can run
+# production — see CLAUDE.md.
+STORE_DIRS="_targets _targets_dev"
 
 # Gitignored directories holding immutable inputs, as repo-relative paths
 # separated by spaces. Topped up per file, every session.
@@ -51,16 +51,13 @@ TOPUP_DIRS="data renv/library"
 # Gitignored directories the pipeline writes, cloned together as one snapshot.
 # The stores belong here, alongside every directory their file targets point at
 # — miss one and each target writing there is rebuilt in the worktree whatever
-# the branch touched, because its file is simply absent.
+# the branch touched, because its file is simply absent. reports/ is here for
+# the .html the two tar_render targets emit.
 #
-# _targets (production) is only its metadata: the objects live in S3, so it costs
-# ~2MB. It is seeded so tar_outdated() tells the truth, not so worktrees can run
-# production — see CLAUDE.md.
-#
-# Order matters: the stamped store goes last. It is what every later run compares
-# against, so a run killed partway leaves a store still matching the stamp,
-# which is what makes the next run re-clone rather than call the mixture seeded.
-SNAPSHOT_DIRS="output _targets $TARGETS_STORE"
+# Order matters: the stores go last. They are what every later run compares
+# against, so a run killed partway leaves them still matching the stamp, which is
+# what makes the next run re-clone rather than call the mixture seeded.
+SNAPSHOT_DIRS="output reports $STORE_DIRS"
 
 repo_root=$(git rev-parse --show-toplevel)
 
@@ -72,13 +69,13 @@ if [ "$repo_root" = "$main_root" ]; then
   exit 0
 fi
 
-# The store's metadata file changes when a target is built and at no other time,
-# so comparing copies of it says which build a store is carrying. The stamp is
-# the copy this worktree was handed when it was last seeded: while the worktree's
-# own store still matches it, nothing has been built here and the snapshot is
-# disposable.
-store_meta="$TARGETS_STORE/meta/meta"
-stamp_file="$repo_root/.seed-worktree-stamp"
+# A store's metadata file changes when a target is built and at no other time, so
+# comparing copies of it says which build that store is carrying. The stamp holds
+# the copies this worktree was handed when it was last seeded: while its own
+# stores still match them, nothing has been built here and the snapshot is
+# disposable. Both stores are stamped, so that a production build made in a
+# worktree is not thrown away on the strength of the dev store alone.
+stamp_dir="$repo_root/.seed-worktree-stamp"
 
 # Opening a workspace can start this script more than once at the same moment —
 # a workspace tool's setup command and the agent's session hook both run it.
@@ -87,17 +84,18 @@ stamp_file="$repo_root/.seed-worktree-stamp"
 # atomically or not at all. A second run has nothing to gain by waiting, since
 # the run holding the lock does its work for it.
 lock_dir="$repo_root/.seed-worktree-lock"
-staged_dirs=()
+# Only ever one staging path at a time: each snapshot directory is staged,
+# moved into place, and the next one started.
+staged=""
 probe=""
-probe_dir=""
+probe_out=""
 
 cleanup() {
   rm -rf "$lock_dir"
   [ -n "$probe" ] && rm -f "$probe"
-  [ -n "$probe_dir" ] && rm -rf "$probe_dir"
-  if [ ${#staged_dirs[@]} -gt 0 ]; then
-    rm -rf "${staged_dirs[@]}"
-  fi
+  [ -n "$probe_out" ] && rm -f "$probe_out"
+  [ -n "$staged" ] && rm -rf "$staged"
+  return 0
 }
 
 if ! mkdir "$lock_dir" 2>/dev/null; then
@@ -111,8 +109,8 @@ if ! mkdir "$lock_dir" 2>/dev/null; then
     holder=$(cat "$lock_dir/pid" 2>/dev/null || true)
   fi
   if [ -n "$holder" ] && kill -0 "$holder" 2>/dev/null; then
-    # Pids are recycled, so this can in principle name something else entirely.
-    # Say where the lock is, so a wedged worktree is one deletion from working.
+    # Pids are recycled, so this can name something else entirely. Say where the
+    # lock is, so a wedged worktree is one deletion from working.
     echo "seed-worktree: another seed (pid $holder) is running here; leaving it to finish."
     echo "seed-worktree: if none is, remove $lock_dir and re-run."
     exit 0
@@ -120,13 +118,12 @@ if ! mkdir "$lock_dir" 2>/dev/null; then
   # Nobody holds it: a previous run was killed — a session hook that outran its
   # timeout, most likely. It staged its copies rather than writing them in
   # place, so nothing here is half-replaced and the lock is safe to take over.
-  # Claim it by renaming, which only one taker-over can win.
+  # Claim it by renaming, which only one taker-over can win; losing either step
+  # means someone else got there first.
   stale_lock="$lock_dir.stale.$$"
-  if ! mv "$lock_dir" "$stale_lock" 2>/dev/null; then
-    echo "seed-worktree: another seed is claiming the lock here; leaving it to finish."
-    exit 0
+  if mv "$lock_dir" "$stale_lock" 2>/dev/null; then
+    rm -rf "$stale_lock"
   fi
-  rm -rf "$stale_lock"
   if ! mkdir "$lock_dir" 2>/dev/null; then
     echo "seed-worktree: another seed is claiming the lock here; leaving it to finish."
     exit 0
@@ -145,6 +142,13 @@ holds_ignored_content() {
   [ -n "$(git -C "$root" ls-files --others --ignored --exclude-standard --directory --no-empty-directory -- "$rel")" ]
 }
 
+stores_present() {
+  local root=$1 rel
+  for rel in $STORE_DIRS; do
+    [ -f "$root/$rel/meta/meta" ] || return 1
+  done
+}
+
 # Whether a checkout's snapshot is whole, which is a stronger question than
 # whether it holds something. A store whose objects arrived but whose meta/ did
 # not is a directory full of gigabytes that targets reads as an empty store,
@@ -154,7 +158,7 @@ snapshot_is_whole() {
   for rel in $SNAPSHOT_DIRS; do
     holds_ignored_content "$root" "$rel" || return 1
   done
-  [ -f "$root/$store_meta" ]
+  stores_present "$root"
 }
 
 for rel in $TOPUP_DIRS $SNAPSHOT_DIRS; do
@@ -170,14 +174,27 @@ for rel in $TOPUP_DIRS $SNAPSHOT_DIRS; do
   fi
 done
 
-# Whether this worktree holds builds of its own. The stamp is the store it was
-# handed; the main checkout's is the store it would be handed now. A store
+# Whether this worktree holds builds of its own, in any store. The stamp is what
+# a store was handed; the main checkout's is what it would be handed now. A store
 # matching either holds nothing that re-cloning would not reproduce — anything
 # else was built here, and is not this script's to replace.
 worktree_has_built() {
-  [ -f "$repo_root/$store_meta" ] &&
-    ! cmp -s "$repo_root/$store_meta" "$stamp_file" &&
-    ! cmp -s "$repo_root/$store_meta" "$main_root/$store_meta"
+  local rel
+  for rel in $STORE_DIRS; do
+    [ -f "$repo_root/$rel/meta/meta" ] || continue
+    if ! cmp -s "$repo_root/$rel/meta/meta" "$stamp_dir/$rel.meta" &&
+      ! cmp -s "$repo_root/$rel/meta/meta" "$main_root/$rel/meta/meta"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+stores_in_step_with_main() {
+  local rel
+  for rel in $STORE_DIRS; do
+    cmp -s "$repo_root/$rel/meta/meta" "$main_root/$rel/meta/meta" || return 1
+  done
 }
 
 worktree_whole=true
@@ -191,27 +208,29 @@ if worktree_has_built; then
   # missing and leave the choice to whoever is here. This is what a directory
   # newly added to SNAPSHOT_DIRS looks like in a worktree that predates it.
   if [ "$worktree_whole" = false ]; then
-    echo "seed-worktree: part of the snapshot here is missing — each of $SNAPSHOT_DIRS should hold data, and the store needs $store_meta." >&2
-    echo "seed-worktree: leaving it alone, because this worktree has built its own store. Until the gap is filled by hand or the whole snapshot replaced, targets rebuilds everything that writes to the missing directory." >&2
+    echo "seed-worktree: part of the snapshot here is missing — each of $SNAPSHOT_DIRS should hold data, and each of $STORE_DIRS needs its meta/meta." >&2
+    echo "seed-worktree: leaving it alone, because this worktree has built a store of its own. Until the gap is filled by hand or the whole snapshot replaced, targets rebuilds everything that writes to the missing directory." >&2
   fi
-elif [ "$worktree_whole" = true ] && cmp -s "$repo_root/$store_meta" "$main_root/$store_meta"; then
+elif [ "$worktree_whole" = true ] && stores_in_step_with_main; then
   snapshot_note="in step with the main checkout"
 else
   snapshot_action="clone"
-  if [ ! -d "$repo_root/$TARGETS_STORE" ]; then
-    snapshot_note="cloned from the main checkout"
-  elif [ "$worktree_whole" = false ]; then
-    snapshot_note="re-cloned: part of it was missing, so an earlier copy had stopped short"
-  else
-    snapshot_note="re-cloned: nothing had been built here and the main checkout's store had moved on"
-  fi
+  # A store directory that exists at all means this is a replacement, not a first
+  # seed — including a torn one, whose meta/ never arrived.
+  snapshot_note="cloned from the main checkout"
+  for rel in $STORE_DIRS; do
+    if [ -d "$repo_root/$rel" ]; then
+      snapshot_note="re-cloned: it was incomplete, or nothing had been built here and the main checkout had moved on"
+      break
+    fi
+  done
 fi
 
 if [ "$snapshot_action" = "clone" ]; then
   # Confirm the source before touching anything, so a main checkout that has
   # never built stops the run instead of leaving the worktree with an empty store.
   if ! snapshot_is_whole "$main_root"; then
-    echo "seed-worktree: the main checkout has no whole snapshot to seed from: it needs gitignored content in $SNAPSHOT_DIRS, and a store at $store_meta." >&2
+    echo "seed-worktree: the main checkout has no whole snapshot to seed from: it needs gitignored content in $SNAPSHOT_DIRS, and a meta/meta in each of $STORE_DIRS." >&2
     echo "seed-worktree: build the pipeline there first." >&2
     exit 1
   fi
@@ -219,9 +238,9 @@ if [ "$snapshot_action" = "clone" ]; then
   # targets records the pid of the process that last wrote a store, and the
   # record outlives the build. Both stores are checked, since either can be mid
   # build while the other is idle. Confirm the pid still belongs to an R process
-  # before believing it: pids get recycled, and a stale one owned by something
-  # unrelated would block every session from here on.
-  for rel in $SNAPSHOT_DIRS; do
+  # before believing it, since a recycled one would otherwise block every session
+  # from here on.
+  for rel in $STORE_DIRS; do
     process_file="$main_root/$rel/meta/process"
     [ -f "$process_file" ] || continue
     builder_pid=$(sed -n 's/^pid|//p' "$process_file")
@@ -274,32 +293,34 @@ if command -v xattr >/dev/null 2>&1; then
   esac
 fi
 
+# Gated so that a session with nothing to do never writes the probe scratch file
+# into the main checkout — which is every session after the first.
 if [ "$snapshot_action" = "clone" ] || [ "$topup_count" -gt 0 ]; then
   # Probe both copy modes with a scratch file along the real copy path, main
   # checkout to worktree, so a cross-volume worktree fails the probe rather than
   # the multi-gigabyte copy.
   probe=$(mktemp "$main_root/.reflink-probe.XXXXXX")
-  probe_dir=$(mktemp -d "$repo_root/.reflink-probe.XXXXXX")
+  probe_out="$repo_root/.reflink-probe.out.$$"
 
   # Reflink flags differ by platform: -c is APFS/macOS, --reflink=always is GNU
   # cp on Btrfs or XFS. ext4 has neither, which is why the inputs are hardlinked
   # rather than cloned; keep the probe so a move to Btrfs is picked up for free.
   clone_flag=""
-  if cp -c "$probe" "$probe_dir/out" 2>/dev/null; then
+  if cp -c "$probe" "$probe_out" 2>/dev/null; then
     clone_flag="-c"
-  elif cp --reflink=always "$probe" "$probe_dir/out" 2>/dev/null; then
+  elif cp --reflink=always "$probe" "$probe_out" 2>/dev/null; then
     clone_flag="--reflink=always"
   fi
-  rm -f "$probe_dir/out"
+  rm -f "$probe_out"
 
   # Hardlinks need one filesystem, same as reflinks, so a worktree on another
   # volume falls back to whatever the snapshot copy uses.
   link_flag="-l"
-  if ! cp -l "$probe" "$probe_dir/out" 2>/dev/null; then
+  if ! cp -l "$probe" "$probe_out" 2>/dev/null; then
     link_flag="$clone_flag"
     echo "seed-worktree: hardlinks do not reach this worktree, so the inputs are copied instead; expect it to be slow and to consume disk." >&2
   fi
-  rm -f "$probe_dir/out"
+  rm -f "$probe_out"
 
   # -p keeps mtimes, which targets uses to skip re-hashing the store. macOS
   # clonefile preserves them regardless; the other two paths do not.
@@ -310,14 +331,37 @@ if [ "$snapshot_action" = "clone" ] || [ "$topup_count" -gt 0 ]; then
   # destination keeps the move a rename within one filesystem.
   if [ "$snapshot_action" = "clone" ]; then
     for rel in $SNAPSHOT_DIRS; do
-      staging="$repo_root/$rel.seed-incoming"
-      rm -rf "$staging"
-      staged_dirs+=("$staging")
-      cp $clone_flag -Rp "$main_root/$rel" "$staging"
+      staged="$repo_root/$rel.seed-incoming"
+      rm -rf "$staged"
+      cp $clone_flag -Rp "$main_root/$rel" "$staged"
+
+      # Tracked files inside a snapshot directory belong to the branch, not to
+      # the snapshot: reports/ holds committed .qmd sources beside the .html
+      # rendered from them, and each store a committed .gitignore. Replacing the
+      # directory wholesale would hand the worktree the main checkout's copies,
+      # silently reverting branch edits and leaving git reporting the difference.
+      # So put this worktree's own versions back over the staged ones — committed
+      # or not, since an uncommitted edit is the one least recoverable.
+      #
+      # A tracked file the worktree no longer has on disk keeps the staged copy
+      # instead of staying deleted: the common way to lose one is deleting a
+      # store directory by hand, and withholding it would leave the worktree
+      # dirty for good.
+      while IFS= read -r -d '' tracked; do
+        [ -e "$repo_root/$tracked" ] || continue
+        staged_file="$staged/${tracked#"$rel/"}"
+        mkdir -p "$(dirname "$staged_file")"
+        cp -p "$repo_root/$tracked" "$staged_file"
+      done < <(git -C "$repo_root" ls-files -z -- "$rel")
+
       rm -rf "${repo_root:?}/$rel"
-      mv "$staging" "$repo_root/$rel"
+      mv "$staged" "$repo_root/$rel"
+      staged=""
     done
-    cp $clone_flag -p "$main_root/$store_meta" "$stamp_file"
+    mkdir -p "$stamp_dir"
+    for rel in $STORE_DIRS; do
+      cp $clone_flag -p "$main_root/$rel/meta/meta" "$stamp_dir/$rel.meta"
+    done
   fi
 
   for ((i = 0; i < topup_count; i++)); do

--- a/scripts/seed-worktree.sh
+++ b/scripts/seed-worktree.sh
@@ -215,11 +215,13 @@ elif [ "$worktree_whole" = true ] && stores_in_step_with_main; then
   snapshot_note="in step with the main checkout"
 else
   snapshot_action="clone"
-  # A store directory that exists at all means this is a replacement, not a first
-  # seed — including a torn one, whose meta/ never arrived.
+  # A store holding any data of its own means this is a replacement, not a first
+  # seed — including a torn one, whose meta/ never arrived. Asking whether the
+  # directory exists would not do: _targets/ carries a tracked .gitignore, so git
+  # materialises it in every fresh worktree.
   snapshot_note="cloned from the main checkout"
   for rel in $STORE_DIRS; do
-    if [ -d "$repo_root/$rel" ]; then
+    if holds_ignored_content "$repo_root" "$rel"; then
       snapshot_note="re-cloned: it was incomplete, or nothing had been built here and the main checkout had moved on"
       break
     fi


### PR DESCRIPTION
## What this is for

Working on two branches at once means two checkouts. But a `git worktree` only
checks out files that are in git — so a new one arrives with all the code and
none of the pipeline: no targets stores, no CNEFE/TSE downloads, no R package
library. The first `tar_make()` there rebuilds everything, including targets the
branch never touched, and a worktree without `renv/library` cannot run R at all.

This adds a script that fills in that missing state from the main checkout when a
worktree starts, so a branch can be built independently without waiting hours for
work that was already done.

## How it works

`scripts/seed-worktree.sh` runs from a `SessionStart` hook, takes about 6 seconds,
and reports what it did and what it skipped. Running it in the main checkout does
nothing. The two seed lists at the top are maintained by hand and treated
differently:

- **Immutable inputs** (`data/`, `renv/library`) are **hardlinked** and topped up
  file by file. This filesystem is ext4 and has no reflinks, so hardlinks are what
  keep a worktree at ~0.8GB instead of ~6.7GB. Nothing in the pipeline writes
  under either path.
- **Directories the pipeline writes** (`output/`, `reports/`, `_targets/`,
  `_targets_dev/`) are copied for real and replaced as one snapshot — only while
  the worktree has built nothing of its own.

Both stores are seeded. `_targets/` costs ~2MB because its objects live in S3; it
is there so `tar_outdated()` tells the truth, not so worktrees can run production.
Every checkout's production store points at the same S3 prefix, so worktrees
should stay in dev mode — `CLAUDE.md` says so and explains why.

The design guards one failure specifically, because it is the one that hides: a
half-copied store still looks seeded, so every later session leaves it alone and
the worktree stays broken for as long as it lives. Hence the lock, the staging
directory, and a seeded-ness test keyed on the file that only exists once the copy
finished.

## Notable details

- Most of `renv/library` is symlinks into the shared renv cache, so they are
  recreated as symlinks rather than followed.
- Tracked files inside a snapshot directory belong to the branch, not the
  snapshot: `reports/` holds committed `.qmd` sources beside the `.html` rendered
  from them. Branch edits are carried across the replacement, committed or not,
  and branch deletions stay deleted.
- The script resolves the checkout to seed from its own location, so invoking it
  by path from elsewhere cannot silently no-op.

## Verification

- 63 edge cases pass on a throwaway repo: fresh seed, top-up restore, symlink
  restore, stale and torn stores, local builds left alone, missing-directory gaps
  reported rather than papered over, live/dead/absent lock holders, and both
  directions of the running-pipeline guard.
- End to end on a real throwaway worktree, `tar_outdated()` returns an identical
  45 targets in both checkouts. (Those 45 are the existing gap between `master`
  and the dev store, not a seeding artifact.)
- Both checkouts clean afterward, no lock, probe, or staging residue.

Reviewed with `/simplify` and `codex exec review`; fixes from both are applied in
the later commits.

## After merging

The hook reaches a worktree only once the script is on the branch it was cut from,
so worktrees created before this merges still need one manual run:

```bash
scripts/seed-worktree.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)