### PR TITLE
Give both CNEFE cleaners the same shape: each reads its own state file

### DIFF
--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -74,28 +74,24 @@ cnefe_especie_labels <- function(year) {
 
 # Cleans CNEFE 2022 into an address table with municipality ids and normalized street/bairro.
 clean_cnefe22 <- function(cnefe22_file, muni_ids) {
-  if (is.character(cnefe22_file)) {
-    cnefe22 <- fread(
-      cnefe22_file,
-      drop = c(
-        "nom_comp_elem1",
-        "val_comp_elem1",
-        "nom_comp_elem2",
-        "val_comp_elem2",
-        "nom_comp_elem3",
-        "val_comp_elem3",
-        "nom_comp_elem4",
-        "val_comp_elem4",
-        "nom_comp_elem5",
-        "val_comp_elem5",
-        "num_quadra",
-        "num_face",
-        "cod_unico_endereco"
-      )
+  cnefe22 <- fread(
+    cnefe22_file,
+    drop = c(
+      "nom_comp_elem1",
+      "val_comp_elem1",
+      "nom_comp_elem2",
+      "val_comp_elem2",
+      "nom_comp_elem3",
+      "val_comp_elem3",
+      "nom_comp_elem4",
+      "val_comp_elem4",
+      "nom_comp_elem5",
+      "val_comp_elem5",
+      "num_quadra",
+      "num_face",
+      "cod_unico_endereco"
     )
-  } else {
-    cnefe22 <- cnefe22_file
-  }
+  )
 
   setnames(cnefe22, names(cnefe22), tolower(names(cnefe22)))
 
@@ -665,79 +661,72 @@ convert_coords_checked <- function(coord_strings, coord_name = "coordinate") {
 }
 
 
-clean_cnefe10 <- function(cnefe_file, muni_ids, tract_centroids, extract_schools = FALSE) {
+# Cleans an already-read CNEFE 2010 state table into an address table; the caller's
+# table is left untouched.
+clean_cnefe10 <- function(cnefe10, muni_ids, tract_centroids, extract_schools = FALSE) {
   # Memory-efficient processing of CNEFE 2010 data
 
   mem_before <- gc()[2, 2]
   message(sprintf("Memory before CNEFE processing: %.1f GB", mem_before / 1024))
 
-  process_chunk <- function(cnefe_chunk) {
-    setnames(cnefe_chunk, names(cnefe_chunk), tolower(names(cnefe_chunk)))
+  cnefe <- copy(cnefe10)
+  setnames(cnefe, names(cnefe), tolower(names(cnefe)))
 
-    # Drop unnecessary columns early to save memory
-    cols_to_drop <- c(
-      "situacao_setor",
-      "nom_comp_elem1",
-      "val_comp_elem1",
-      "nom_comp_elem2",
-      "val_comp_elem2",
-      "nom_comp_elem3",
-      "val_comp_elem3",
-      "nom_comp_elem4",
-      "val_comp_elem4",
-      "nom_comp_elem5",
-      "val_comp_elem5",
-      "indicador_endereco",
-      "num_quadra",
-      "num_face",
-      "cep_face",
-      "cod_unico_endereco"
-    )
+  # Drop unnecessary columns early to save memory
+  cols_to_drop <- c(
+    "situacao_setor",
+    "nom_comp_elem1",
+    "val_comp_elem1",
+    "nom_comp_elem2",
+    "val_comp_elem2",
+    "nom_comp_elem3",
+    "val_comp_elem3",
+    "nom_comp_elem4",
+    "val_comp_elem4",
+    "nom_comp_elem5",
+    "val_comp_elem5",
+    "indicador_endereco",
+    "num_quadra",
+    "num_face",
+    "cep_face",
+    "cod_unico_endereco"
+  )
 
-    cnefe_chunk[, (cols_to_drop) := NULL]
+  cnefe[, (cols_to_drop) := NULL]
 
-    cnefe_chunk[, cod_municipio := str_pad(cod_municipio, width = 5, side = "left", pad = "0")]
-    cnefe_chunk[, cod_distrito := str_pad(cod_distrito, width = 2, side = "left", pad = "0")]
-    cnefe_chunk[, cod_subdistrito := str_pad(cod_subdistrito, width = 2, side = "left", pad = "0")]
-    cnefe_chunk[, cod_setor := str_pad(cod_setor, width = 4, side = "left", pad = "0")]
-    cnefe_chunk[, setor_code := paste0(cod_uf, cod_municipio, cod_distrito, cod_subdistrito, cod_setor)]
-    cnefe_chunk[, c("cod_distrito", "cod_subdistrito", "cod_setor") := NULL]
+  cnefe[, cod_municipio := str_pad(cod_municipio, width = 5, side = "left", pad = "0")]
+  cnefe[, cod_distrito := str_pad(cod_distrito, width = 2, side = "left", pad = "0")]
+  cnefe[, cod_subdistrito := str_pad(cod_subdistrito, width = 2, side = "left", pad = "0")]
+  cnefe[, cod_setor := str_pad(cod_setor, width = 4, side = "left", pad = "0")]
+  cnefe[, setor_code := paste0(cod_uf, cod_municipio, cod_distrito, cod_subdistrito, cod_setor)]
+  cnefe[, c("cod_distrito", "cod_subdistrito", "cod_setor") := NULL]
 
-    # Street address used by matching; the house-number/modifier fields feed nothing downstream.
-    cnefe_chunk[, street := str_squish(paste(nom_tipo_seglogr, nom_titulo_seglogr, nom_seglogr))]
+  # Street address used by matching; the house-number/modifier fields feed nothing downstream.
+  cnefe[, street := str_squish(paste(nom_tipo_seglogr, nom_titulo_seglogr, nom_seglogr))]
 
-    cnefe_chunk[, c("nom_tipo_seglogr", "nom_titulo_seglogr", "num_endereco", "nom_seglogr", "dsc_modificador") := NULL]
+  cnefe[, c("nom_tipo_seglogr", "nom_titulo_seglogr", "num_endereco", "nom_seglogr", "dsc_modificador") := NULL]
 
-    cnefe_chunk[val_longitude == "", val_longitude := NA]
-    cnefe_chunk[val_latitude == "", val_latitude := NA]
-    cnefe_chunk[dsc_estabelecimento == "", dsc_estabelecimento := NA]
-    cnefe_chunk[, dsc_estabelecimento := str_squish(dsc_estabelecimento)]
+  cnefe[val_longitude == "", val_longitude := NA]
+  cnefe[val_latitude == "", val_latitude := NA]
+  cnefe[dsc_estabelecimento == "", dsc_estabelecimento := NA]
+  cnefe[, dsc_estabelecimento := str_squish(dsc_estabelecimento)]
 
-    # cod_municipio was padded above for setor_code; make_id_munic_7 re-pads idempotently.
-    cnefe_chunk[, id_munic_7 := make_id_munic_7(cod_uf, cod_municipio)]
+  # cod_municipio was padded above for setor_code; make_id_munic_7 re-pads idempotently.
+  cnefe[, id_munic_7 := make_id_munic_7(cod_uf, cod_municipio)]
 
-    essential_cols <- c(
-      "id_munic_7",
-      "setor_code",
-      "especie",
-      "street",
-      "dsc_localidade",
-      "dsc_estabelecimento",
-      "val_longitude",
-      "val_latitude"
-    )
-    cnefe_chunk <- cnefe_chunk[, ..essential_cols]
+  essential_cols <- c(
+    "id_munic_7",
+    "setor_code",
+    "especie",
+    "street",
+    "dsc_localidade",
+    "dsc_estabelecimento",
+    "val_longitude",
+    "val_latitude"
+  )
+  cnefe <- cnefe[, ..essential_cols]
 
-    gc(verbose = FALSE)
-    return(cnefe_chunk)
-  }
-
-  if (is.character(cnefe_file)) {
-    cnefe <- fread(cnefe_file, sep = ";", encoding = "UTF-8")
-    cnefe <- process_chunk(cnefe)
-  } else {
-    cnefe <- process_chunk(copy(cnefe_file))
-  }
+  gc(verbose = FALSE)
 
   message("Merging municipality identifiers...")
   cnefe <- muni_ids[, .(id_munic_7, id_TSE, municipio, estado_abrev)][

--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -661,15 +661,15 @@ convert_coords_checked <- function(coord_strings, coord_name = "coordinate") {
 }
 
 
-# Cleans an already-read CNEFE 2010 state table into an address table; the caller's
-# table is left untouched.
-clean_cnefe10 <- function(cnefe10, muni_ids, tract_centroids, extract_schools = FALSE) {
+# Cleans one CNEFE 2010 state file into an address table with municipality ids and
+# normalized street/bairro. The 2010 state files are comma-separated.
+clean_cnefe10 <- function(cnefe10_file, muni_ids, tract_centroids, extract_schools = FALSE) {
   # Memory-efficient processing of CNEFE 2010 data
 
   mem_before <- gc()[2, 2]
   message(sprintf("Memory before CNEFE processing: %.1f GB", mem_before / 1024))
 
-  cnefe <- copy(cnefe10)
+  cnefe <- fread(cnefe10_file, sep = ",", encoding = "UTF-8", showProgress = FALSE)
   setnames(cnefe, names(cnefe), tolower(names(cnefe)))
 
   # Drop unnecessary columns early to save memory

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -98,14 +98,6 @@ process_cnefe_state <- function(state_file, year, muni_ids, tract_centroids = NU
   }
 
   if (year == 2010) {
-    state_data <- fread(
-      state_file,
-      sep = ",",
-      encoding = "UTF-8",
-      verbose = FALSE,
-      showProgress = FALSE
-    )
-
     state_codes <- unique(substr(
       as.character(state_muni_ids$id_munic_7),
       1,
@@ -117,7 +109,7 @@ process_cnefe_state <- function(state_file, year, muni_ids, tract_centroids = NU
 
     # Schools come out of the same in-memory pass, so the state file is read once.
     cleaned <- clean_cnefe10(
-      cnefe10 = state_data,
+      cnefe10_file = state_file,
       muni_ids = state_muni_ids,
       tract_centroids = state_tract_centroids,
       extract_schools = TRUE

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -117,7 +117,7 @@ process_cnefe_state <- function(state_file, year, muni_ids, tract_centroids = NU
 
     # Schools come out of the same in-memory pass, so the state file is read once.
     cleaned <- clean_cnefe10(
-      cnefe_file = state_data,
+      cnefe10 = state_data,
       muni_ids = state_muni_ids,
       tract_centroids = state_tract_centroids,
       extract_schools = TRUE


### PR DESCRIPTION
Closes #99.

## What this is for

Two functions clean CNEFE census files — one for the 2010 vintage, one for 2022. Both accepted *either* a file path or an already-loaded table, and picked a branch at runtime. In each function only one of those two branches was ever used, and they were opposite ones: the 2010 cleaner was only ever handed a table, the 2022 cleaner only ever a path. The unused 2010 branch also carried a wrong constant — it read the comma-separated 2010 files as if they were semicolon-separated, which would have produced a single 32-name column for anyone who called it that way.

This removes the guesswork. Each cleaner now takes a path and reads its own file, so the two siblings read the same way and the details of a file format sit next to the code that depends on them.

## Changes

- `clean_cnefe10()` takes a path and reads it with `sep = ","` — the separator the 2010 state files actually use.
- `clean_cnefe22()` takes a path only; its unused in-memory branch is gone.
- `process_cnefe_state()` no longer freads for 2010, so it no longer needs to know how a CNEFE file is laid out.
- The one-use `process_chunk()` closure inside `clean_cnefe10()` is inlined.

Reading inside the cleaner also removes a full duplicate of the raw state table. Previously the caller read it and `clean_cnefe10()` worked on a `copy()`, keeping both alive for the whole call — roughly 2x peak memory on the largest states, on targets that already run under the `memory_limited` controller.

## Verification

- `process_cnefe_state()` on AC for both years returns identical row counts before and after: 2010 → 8121 street / 2978 bairro / 1407 schools; 2022 → 9278 / 3440 / 1713.
- `Rscript tests/testthat.R`: 204 pass, 0 fail.
- `/simplify` (4 agents) and `codex exec review --base master` both ran; Codex found no regression. The simplify pass produced the reshape above, plus one out-of-scope finding filed as #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)