### PR TITLE
Replace the per-pair blocking loop with a word-table join

### DIFF
--- a/R/panel_creation.R
+++ b/R/panel_creation.R
@@ -545,26 +545,45 @@ create_two_level_blocked_pairs <- function(data1, data2) {
   x_all_words <- extract_significant_words(scored_text(data1, unique_x))
   y_all_words <- extract_significant_words(scored_text(data2, unique_y))
 
-  x_lookup <- match(x_indices, unique_x)
-  y_lookup <- match(y_indices, unique_y)
+  x_thin <- lengths(x_all_words) < min_words
+  y_thin <- lengths(y_all_words) < min_words
 
-  keep_pair <- logical(nrow(pairs))
-  no_words_count <- 0
-  no_match_count <- 0
-
-  for (i in seq_len(nrow(pairs))) {
-    x_words <- x_all_words[[x_lookup[i]]]
-    y_words <- y_all_words[[y_lookup[i]]]
-
-    if (length(x_words) < min_words || length(y_words) < min_words) {
-      keep_pair[i] <- TRUE
-      no_words_count <- no_words_count + 1
-    } else {
-      has_match <- any(x_words %in% y_words)
-      keep_pair[i] <- has_match
-      if (!has_match) no_match_count <- no_match_count + 1
-    }
+  # Word -> record tables driving the overlap test. Municipality rides along as part of the
+  # join key, so the join can only produce pairs municipality blocking already allows —
+  # without it a word common across the state would cross-join every record holding it.
+  # Thin records are left out: their pairs are kept whatever the overlap.
+  word_table <- function(word_lists, thin, muni_by_slot) {
+    slot <- rep.int(seq_along(word_lists), lengths(word_lists))
+    keep <- !thin[slot]
+    data.table(
+      slot = slot[keep],
+      word = unlist(word_lists, use.names = FALSE)[keep],
+      muni = muni_by_slot[slot[keep]]
+    )
   }
+  x_words <- word_table(x_all_words, x_thin, data1$cod_localidade_ibge[unique_x])
+  y_words <- word_table(y_all_words, y_thin, data2$cod_localidade_ibge[unique_y])
+  setnames(x_words, "slot", "x_slot")
+  setnames(y_words, "slot", "y_slot")
+
+  # "Shares at least one significant word" as a set intersection over the word tables,
+  # rather than a scan over the (millions of) blocked pairs.
+  shared <- unique(
+    merge(x_words, y_words, by = c("muni", "word"), allow.cartesian = TRUE)[, .(x_slot, y_slot)]
+  )
+
+  pair_slots <- data.table(
+    x_slot = match(x_indices, unique_x),
+    y_slot = match(y_indices, unique_y),
+    shares_word = FALSE
+  )
+  pair_slots[shared, shares_word := TRUE, on = c("x_slot", "y_slot")]
+
+  thin_pair <- x_thin[pair_slots$x_slot] | y_thin[pair_slots$y_slot]
+  keep_pair <- thin_pair | pair_slots$shares_word
+
+  no_words_count <- sum(thin_pair)
+  no_match_count <- sum(!keep_pair)
 
   if (no_match_count > 0) {
     cat("    Note: ", no_match_count, " pairs excluded (no shared words)\n", sep = "")

--- a/tests/testthat/test-create_two_level_blocked_pairs.R
+++ b/tests/testthat/test-create_two_level_blocked_pairs.R
@@ -1,0 +1,76 @@
+## Spec tests for create_two_level_blocked_pairs() (R/panel_creation.R).
+## It pairs records that share a municipality, then keeps only those whose name/address
+## share at least one significant word (stopwords and words under 3 characters do not
+## count). A record left with fewer than two significant words cannot be judged on
+## overlap, so all of its pairs are kept.
+##
+## The function prints progress via cat(); capture.output() keeps test output clean.
+
+blocked <- function(data1, data2) {
+  invisible(capture.output(out <- create_two_level_blocked_pairs(data1, data2)))
+  data.table::data.table(x = data1$local_id[out$.x], y = data2$local_id[out$.y])
+}
+
+test_that("create_two_level_blocked_pairs keeps only pairs sharing a significant word", {
+  year1 <- data.table::data.table(
+    local_id = c("a_escola", "a_hospital"),
+    cod_localidade_ibge = 1L,
+    normalized_name = c("escola central", "hospital norte"),
+    normalized_addr = c("rua amapa", "avenida bahia")
+  )
+  year2 <- data.table::data.table(
+    local_id = c("b_escola", "b_hospital"),
+    cod_localidade_ibge = 1L,
+    normalized_name = c("escola central", "hospital norte"),
+    normalized_addr = c("rua amapa", "avenida bahia")
+  )
+
+  kept <- blocked(year1, year2)
+
+  # "escola", "rua" and "avenida" are stopwords, so only the distinguishing words pair up.
+  expect_setequal(paste(kept$x, kept$y), c("a_escola b_escola", "a_hospital b_hospital"))
+})
+
+test_that("create_two_level_blocked_pairs never pairs across municipalities", {
+  year1 <- data.table::data.table(
+    local_id = c("m1", "m2"),
+    cod_localidade_ibge = c(1L, 2L),
+    normalized_name = "escola central",
+    normalized_addr = "rua amapa"
+  )
+  year2 <- data.table::data.table(
+    local_id = c("m1_later", "m2_later"),
+    cod_localidade_ibge = c(1L, 2L),
+    normalized_name = "escola central",
+    normalized_addr = "rua amapa"
+  )
+
+  kept <- blocked(year1, year2)
+
+  expect_setequal(paste(kept$x, kept$y), c("m1 m1_later", "m2 m2_later"))
+})
+
+test_that("create_two_level_blocked_pairs keeps every pair of a word-thin record", {
+  year1 <- data.table::data.table(
+    local_id = c("thin", "rich"),
+    cod_localidade_ibge = 1L,
+    # "thin" is left with one significant word once stopwords and short words go.
+    normalized_name = c("escola", "hospital norte"),
+    normalized_addr = c("rua", "avenida bahia")
+  )
+  year2 <- data.table::data.table(
+    local_id = c("other", "match"),
+    cod_localidade_ibge = 1L,
+    normalized_name = c("creche amazonas", "hospital norte"),
+    normalized_addr = c("rua parana", "avenida bahia")
+  )
+
+  kept <- blocked(year1, year2)
+
+  # The thin record shares no word with either year-2 record but is kept against both;
+  # the rich record is filtered on overlap as usual.
+  expect_setequal(
+    paste(kept$x, kept$y),
+    c("thin other", "thin match", "rich match")
+  )
+})


### PR DESCRIPTION
## What this is for

Panel creation pairs every polling station in one election year with every station in the next year of the same municipality, then throws away the pairs whose name and address have no word in common. That last filter walked the pair list one row at a time in R. For a big city the list is millions of rows, and it runs once per year transition inside the ~38h `panel_ids_by_batch` target.

This replaces the loop with a join, keeping the same rule and the same output.

Closes #100.

## How

- Build word → record tables for each year slice (the tokenization above it was already deduplicated per record). Municipality is part of the join key, so the join can only produce pairs municipality blocking already allows — without it a word common across a state would cross-join every record holding it.
- Join the two tables to get the pairs that share at least one significant word.
- The thin-record fallback (a record left with fewer than two significant words is kept whatever the overlap) becomes a vector predicate on the word counts, and the two `cat()` counters fall out of the resulting logical vectors.

## Verification

- **Bit-identical**: ran both implementations over every municipality/year transition in the dev-mode AC/RR table — 333 blocks, 878k candidate pairs — and compared the returned `.x`/`.y` vectors. No differences.
- **Speed**, on a synthetic single-municipality block built from real AC/RR name/address strings:

  | block | candidate pairs | loop | join | speedup |
  |---|---|---|---|---|
  | 1000 × 1000 | 1M | 0.95s | 0.17s | 5.6× |
  | 2000 × 2000 | 4M | 3.68s | 0.36s | 10.1× |
  | 4000 × 4000 | 16M | 14.29s | 1.16s | 12.4× |

- `tests/testthat.R`: 207 pass, 0 fail (in a UTF-8 locale; three tests fail under a `C` locale on master too, unrelated).
- `TAR_PROJECT=dev tar_make(names = c("panel_ids", "section_panel_mapping"))` completes.
- New spec test file covering the three cases the rule has: shared word keeps, no shared word drops, thin record keeps everything — plus that pairs never cross a municipality.

## Note on sequencing

This invalidates the panel targets, so it wants the next full-rebuild window rather than a rebuild of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)