### PR TITLE
Route every per-municipality batch loop through collect_batch_or_stop()

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -249,9 +249,6 @@ process_inep_batch <- function(municipality_batch_assignments, locais_filtered, 
   data.table::setkey(inep_data, id_munic_7)
   data.table::setkey(locais_filtered, cod_localidade_ibge)
 
-  # A NULL result (no polling stations, or no matches) is a legitimate empty case
-  # and is filtered out; a municipality that errors is named at batch end rather
-  # than aborting the batch anonymously.
   batch_results <- collect_batch_or_stop(
     batch_munis,
     function(muni_code) {
@@ -263,8 +260,8 @@ process_inep_batch <- function(municipality_batch_assignments, locais_filtered, 
     task_label = "INEP matching"
   )
 
-  # rbindlist() of an empty list returns an empty data.table, so a batch whose
-  # municipalities all matched nothing needs no special case.
+  # A batch whose municipalities all matched nothing needs no special case:
+  # rbindlist() of an empty list is an empty data.table.
   rbindlist(batch_results, use.names = TRUE, fill = TRUE)
 }
 
@@ -278,7 +275,6 @@ process_schools_cnefe_batch <- function(municipality_batch_assignments, locais_f
   data.table::setkey(schools_cnefe, id_munic_7)
   data.table::setkey(locais_filtered, cod_localidade_ibge)
 
-  # NULL and error handling as in process_inep_batch().
   batch_results <- collect_batch_or_stop(
     batch_munis,
     function(muni_code) {
@@ -301,9 +297,6 @@ process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, l
 
   data.table::setkey(locais_filtered, cod_localidade_ibge)
 
-  # A NULL result (no polling stations, or no geocoding hits) is a legitimate
-  # empty case and is filtered out; a municipality that errors is reported at
-  # batch end rather than silently dropped.
   results <- collect_batch_or_stop(
     batch_munis,
     function(muni_code) {
@@ -343,9 +336,6 @@ process_stbairro_batch <- function(
     length(batch_munis)
   ))
 
-  # A NULL result (no polling stations, or no matches) is a legitimate empty case
-  # and is filtered out; a municipality that errors is named at batch end rather
-  # than aborting the batch anonymously.
   batch_results <- collect_batch_or_stop(
     batch_munis,
     function(muni_code) {
@@ -353,6 +343,8 @@ process_stbairro_batch <- function(
       st_muni <- st[.(muni_code), nomatch = NULL]
       bairro_muni <- bairro[.(muni_code), nomatch = NULL]
 
+      # Logged before the match, not after: a municipality with a large distance
+      # matrix can run for minutes, and this is the line that says which one.
       message(sprintf(
         "[Batch %d] Processing municipality %s: %d polling stations, %d streets, %d neighborhoods",
         this_batch,
@@ -362,16 +354,7 @@ process_stbairro_batch <- function(
         nrow(bairro_muni)
       ))
 
-      result <- match_stbairro_muni(locais_muni, st_muni, bairro_muni)
-
-      message(sprintf(
-        "[Batch %d] Completed municipality %s: %d matches",
-        this_batch,
-        muni_code,
-        if (is.null(result)) 0L else nrow(result)
-      ))
-
-      result
+      match_stbairro_muni(locais_muni, st_muni, bairro_muni)
     },
     task_label = sprintf("%s street/neighborhood matching", label)
   )

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -249,19 +249,23 @@ process_inep_batch <- function(municipality_batch_assignments, locais_filtered, 
   data.table::setkey(inep_data, id_munic_7)
   data.table::setkey(locais_filtered, cod_localidade_ibge)
 
-  batch_results <- lapply(batch_munis, function(muni_code) {
-    match_inep_muni(
-      locais_muni = locais_filtered[.(muni_code), nomatch = NULL],
-      inep_muni = inep_data[.(muni_code), nomatch = NULL]
-    )
-  })
+  # A NULL result (no polling stations, or no matches) is a legitimate empty case
+  # and is filtered out; a municipality that errors is named at batch end rather
+  # than aborting the batch anonymously.
+  batch_results <- collect_batch_or_stop(
+    batch_munis,
+    function(muni_code) {
+      match_inep_muni(
+        locais_muni = locais_filtered[.(muni_code), nomatch = NULL],
+        inep_muni = inep_data[.(muni_code), nomatch = NULL]
+      )
+    },
+    task_label = "INEP matching"
+  )
 
-  batch_results <- batch_results[!sapply(batch_results, is.null)]
-  if (length(batch_results) > 0) {
-    rbindlist(batch_results, use.names = TRUE, fill = TRUE)
-  } else {
-    data.table()
-  }
+  # rbindlist() of an empty list returns an empty data.table, so a batch whose
+  # municipalities all matched nothing needs no special case.
+  rbindlist(batch_results, use.names = TRUE, fill = TRUE)
 }
 
 # Match one batch's polling stations against the CNEFE school rows.
@@ -274,19 +278,19 @@ process_schools_cnefe_batch <- function(municipality_batch_assignments, locais_f
   data.table::setkey(schools_cnefe, id_munic_7)
   data.table::setkey(locais_filtered, cod_localidade_ibge)
 
-  batch_results <- lapply(batch_munis, function(muni_code) {
-    match_schools_cnefe_muni(
-      locais_muni = locais_filtered[.(muni_code), nomatch = NULL],
-      schools_cnefe_muni = schools_cnefe[.(muni_code), nomatch = NULL]
-    )
-  })
+  # NULL and error handling as in process_inep_batch().
+  batch_results <- collect_batch_or_stop(
+    batch_munis,
+    function(muni_code) {
+      match_schools_cnefe_muni(
+        locais_muni = locais_filtered[.(muni_code), nomatch = NULL],
+        schools_cnefe_muni = schools_cnefe[.(muni_code), nomatch = NULL]
+      )
+    },
+    task_label = "CNEFE school matching"
+  )
 
-  batch_results <- batch_results[!sapply(batch_results, is.null)]
-  if (length(batch_results) > 0) {
-    rbindlist(batch_results, use.names = TRUE, fill = TRUE)
-  } else {
-    data.table()
-  }
+  rbindlist(batch_results, use.names = TRUE, fill = TRUE)
 }
 
 # Geocode one batch's polling stations with geocodebr.
@@ -308,11 +312,7 @@ process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, l
     task_label = "geocodebr matching"
   )
 
-  if (length(results) > 0) {
-    rbindlist(results, use.names = TRUE, fill = TRUE)
-  } else {
-    data.table()
-  }
+  rbindlist(results, use.names = TRUE, fill = TRUE)
 }
 
 # Street/neighborhood match batch, shared by the CNEFE and Agro CNEFE vintages.
@@ -383,11 +383,7 @@ process_stbairro_batch <- function(
     length(batch_results)
   ))
 
-  if (length(batch_results) > 0) {
-    rbindlist(batch_results, use.names = TRUE, fill = TRUE)
-  } else {
-    data.table()
-  }
+  rbindlist(batch_results, use.names = TRUE, fill = TRUE)
 }
 
 # Size-balanced batch assignment for the polling-station municipalities, so the

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -317,7 +317,8 @@ process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, l
 
 # Street/neighborhood match batch, shared by the CNEFE and Agro CNEFE vintages.
 # stbairro is this batch's slice: the union of the street and neighborhood
-# aggregates, tagged by `component`. `label` names the vintage in the log only.
+# aggregates, tagged by `component`. `label` names the vintage in the log and in
+# any failure message.
 process_stbairro_batch <- function(
   municipality_batch_assignments,
   locais_filtered,
@@ -342,52 +343,43 @@ process_stbairro_batch <- function(
     length(batch_munis)
   ))
 
-  batch_results <- lapply(seq_along(batch_munis), function(i) {
-    muni_code <- batch_munis[i]
+  # A NULL result (no polling stations, or no matches) is a legitimate empty case
+  # and is filtered out; a municipality that errors is named at batch end rather
+  # than aborting the batch anonymously.
+  batch_results <- collect_batch_or_stop(
+    batch_munis,
+    function(muni_code) {
+      locais_muni <- locais_filtered[.(muni_code), nomatch = NULL]
+      st_muni <- st[.(muni_code), nomatch = NULL]
+      bairro_muni <- bairro[.(muni_code), nomatch = NULL]
 
-    locais_muni <- locais_filtered[.(muni_code), nomatch = NULL]
-    st_muni <- st[.(muni_code), nomatch = NULL]
-    bairro_muni <- bairro[.(muni_code), nomatch = NULL]
-
-    message(sprintf(
-      "[Batch %d - %d/%d] Processing municipality %s: %d polling stations, %d streets, %d neighborhoods",
-      this_batch,
-      i,
-      length(batch_munis),
-      muni_code,
-      nrow(locais_muni),
-      nrow(st_muni),
-      nrow(bairro_muni)
-    ))
-
-    result <- match_stbairro_muni(locais_muni, st_muni, bairro_muni)
-
-    if (!is.null(result)) {
       message(sprintf(
-        "[Batch %d - %d/%d] Completed municipality %s: %d matches",
+        "[Batch %d] Processing municipality %s: %d polling stations, %d streets, %d neighborhoods",
         this_batch,
-        i,
-        length(batch_munis),
         muni_code,
-        nrow(result)
+        nrow(locais_muni),
+        nrow(st_muni),
+        nrow(bairro_muni)
       ))
-    }
 
-    result
-  })
+      result <- match_stbairro_muni(locais_muni, st_muni, bairro_muni)
 
-  batch_results <- batch_results[!sapply(batch_results, is.null)]
+      message(sprintf(
+        "[Batch %d] Completed municipality %s: %d matches",
+        this_batch,
+        muni_code,
+        if (is.null(result)) 0L else nrow(result)
+      ))
 
-  total_matches <- if (length(batch_results) > 0) {
-    sum(sapply(batch_results, nrow))
-  } else {
-    0
-  }
+      result
+    },
+    task_label = sprintf("%s street/neighborhood matching", label)
+  )
 
   message(sprintf(
     "[Batch %d] Completed with %d total matches from %d municipalities",
     this_batch,
-    total_matches,
+    sum(vapply(batch_results, nrow, integer(1))),
     length(batch_results)
   ))
 


### PR DESCRIPTION
## What this is for

When the pipeline matches polling stations to reference data, it works one municipality at a time, in batches of about fifteen. If one municipality hits an error, we want to know *which* one — after hours of matching, "the batch failed" is not a useful thing to be told.

One helper already does this: it runs the whole batch, remembers every municipality that failed, and stops at the end naming all of them. Four of the batch stages didn't use it. They stopped at the first error without saying where, and hid any further failures behind it. The three street/neighborhood stages that behaved this way are the most expensive matching targets in the pipeline, so they are the ones where an anonymous failure costs the most.

This routes them all through the shared helper.

Closes #104.

## Changes

All in `R/utilities.R`, net −29 lines:

- `process_stbairro_batch()`, `process_inep_batch()`, and `process_schools_cnefe_batch()` call `collect_batch_or_stop()` instead of hand-rolling `lapply()` + `batch_results[!sapply(batch_results, is.null)]`. `process_geocodebr_batch()` already did.
- Dropped the `if (length(x) > 0) rbindlist(x) else data.table()` tail from all four. `rbindlist(list(), use.names = TRUE, fill = TRUE)` is `identical()` to `data.table()`, so the branch was dead.
- `process_stbairro_batch()` logs each municipality once (before the match) rather than twice. The per-municipality `i/N` counter is gone — the helper's callback receives the item, not an index — and the municipality code is what identifies the work anyway.

Failure output now looks like:

```
Agro CNEFE street/neighborhood matching failed for 2 municipalities:
  1200401: <message>
  1200450: <message>
```

## Verification

- Stubbed-matcher tests on each refactored function: two erroring municipalities both named in a single error, `NULL` results still dropped, an all-empty batch still returns an empty `data.table`.
- `Rscript tests/testthat.R` — 204 pass, 0 fail.
- Dev-mode (AC/RR) rebuild of all seven affected batch targets, master vs. this branch: **byte-identical**. Same row counts and digests for `inep_string_match_batch`, `schools_cnefe10_match_batch`, `schools_cnefe22_match_batch`, `geocodebr_match_batch`, and the three `*_stbairro_match_batch` targets. Only the error path and the logs change.

## Review

`/simplify` with the paper-code standard (single file, one concern, output verified identical — not the tier that also needs a Codex pass). Reuse and efficiency clean; simplification and altitude both flagged the call-site comments as restating the helper's own header, and those are cut.

Two findings deliberately skipped:

- **Collapsing the four `process_*_batch()` functions into one parameterized function.** What remains after the helper absorbed the shared part differs at every joint: scalar vs. derived batch id, one key vs. two, differently-named matcher arguments. It would cost three parameters of machinery and make `_targets.R` read `process_ref_batch(matcher = ...)` instead of a named stage.
- **Dropping `task_label` in favor of the target name.** These stages run on detached `crew` workers where the error can surface apart from the target banner, and the change would reach into `panel_creation.R`, outside this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)