### PR TITLE
Drop clean_cnefe10()'s dead extract_schools parameter and unify the CNEFE return shapes

### DIFF
--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -592,11 +592,12 @@ calc_muni_area <- function(muni_shp) {
   muni_shp[, .(cod_localidade_ibge = code_muni, area)]
 }
 
-get_cnefe22_schools <- function(cnefe22) {
-  # Extract schools from the CNEFE 2022 data
-  schools_cnefe22 <- cnefe22[especie_lab == "estabelecimento de ensino"]
-  schools_cnefe22[, norm_desc := normalize_school(desc)]
-  schools_cnefe22[norm_desc != ""]
+# School rows of a cleaned CNEFE table (either year). An empty norm_desc has no name
+# to match on, so those rows are dropped.
+get_cnefe_schools <- function(cnefe) {
+  schools <- cnefe[especie_lab == "estabelecimento de ensino"]
+  schools[, norm_desc := normalize_school(desc)]
+  schools[norm_desc != ""]
 }
 
 convert_coords_dms <- function(coord_strings) {
@@ -661,8 +662,6 @@ convert_coords_checked <- function(coord_strings, coord_name = "coordinate") {
 # Cleans one CNEFE 2010 state file into an address table with municipality ids and
 # normalized street/bairro, plus the school subset. The 2010 state files are comma-separated.
 clean_cnefe10 <- function(cnefe10_file, muni_ids, tract_centroids) {
-  # Memory-efficient processing of CNEFE 2010 data
-
   mem_before <- gc()[2, 2]
   message(sprintf("Memory before CNEFE processing: %.1f GB", mem_before / 1024))
 
@@ -779,15 +778,11 @@ clean_cnefe10 <- function(cnefe10_file, muni_ids, tract_centroids) {
   gc(verbose = FALSE)
 
   message("Extracting schools...")
-  # An empty norm_desc has no name to match, so drop it (as get_cnefe22_schools() does).
-  schools <- addr[especie_lab == "estabelecimento de ensino"]
-  schools[, norm_desc := normalize_school(desc)]
-  schools <- schools[norm_desc != ""]
+  schools <- get_cnefe_schools(addr)
   message(sprintf("Extracted %s schools", format(nrow(schools), big.mark = ",")))
 
   mem_after <- gc()[2, 2]
   message(sprintf("Memory after CNEFE processing: %.1f GB", mem_after / 1024))
-  message("CNEFE processing complete")
 
   list(data = addr, schools = schools)
 }

--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -660,7 +660,7 @@ convert_coords_checked <- function(coord_strings, coord_name = "coordinate") {
 
 
 # Cleans one CNEFE 2010 state file into an address table with municipality ids and
-# normalized street/bairro, plus the school subset. The 2010 state files are comma-separated.
+# normalized street/bairro. The 2010 state files are comma-separated.
 clean_cnefe10 <- function(cnefe10_file, muni_ids, tract_centroids) {
   mem_before <- gc()[2, 2]
   message(sprintf("Memory before CNEFE processing: %.1f GB", mem_before / 1024))
@@ -775,16 +775,10 @@ clean_cnefe10 <- function(cnefe10_file, muni_ids, tract_centroids) {
   addr[, norm_bairro := normalize_address(bairro)]
   addr[, norm_street := normalize_address(street)]
 
-  gc(verbose = FALSE)
-
-  message("Extracting schools...")
-  schools <- get_cnefe_schools(addr)
-  message(sprintf("Extracted %s schools", format(nrow(schools), big.mark = ",")))
-
   mem_after <- gc()[2, 2]
   message(sprintf("Memory after CNEFE processing: %.1f GB", mem_after / 1024))
 
-  list(data = addr, schools = schools)
+  addr
 }
 
 

--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -659,8 +659,8 @@ convert_coords_checked <- function(coord_strings, coord_name = "coordinate") {
 
 
 # Cleans one CNEFE 2010 state file into an address table with municipality ids and
-# normalized street/bairro. The 2010 state files are comma-separated.
-clean_cnefe10 <- function(cnefe10_file, muni_ids, tract_centroids, extract_schools = FALSE) {
+# normalized street/bairro, plus the school subset. The 2010 state files are comma-separated.
+clean_cnefe10 <- function(cnefe10_file, muni_ids, tract_centroids) {
   # Memory-efficient processing of CNEFE 2010 data
 
   mem_before <- gc()[2, 2]
@@ -778,28 +778,18 @@ clean_cnefe10 <- function(cnefe10_file, muni_ids, tract_centroids, extract_schoo
 
   gc(verbose = FALSE)
 
-  if (extract_schools) {
-    message("Extracting schools...")
-    # An empty norm_desc has no name to match, so drop it (as get_cnefe22_schools() does).
-    schools <- addr[especie_lab == "estabelecimento de ensino"]
-    schools[, norm_desc := normalize_school(desc)]
-    schools <- schools[norm_desc != ""]
-    message(sprintf("Extracted %s schools", format(nrow(schools), big.mark = ",")))
-
-    gc(verbose = FALSE)
-    message("CNEFE processing complete")
-
-    return(list(
-      data = addr,
-      schools = schools
-    ))
-  }
+  message("Extracting schools...")
+  # An empty norm_desc has no name to match, so drop it (as get_cnefe22_schools() does).
+  schools <- addr[especie_lab == "estabelecimento de ensino"]
+  schools[, norm_desc := normalize_school(desc)]
+  schools <- schools[norm_desc != ""]
+  message(sprintf("Extracted %s schools", format(nrow(schools), big.mark = ",")))
 
   mem_after <- gc()[2, 2]
   message(sprintf("Memory after CNEFE processing: %.1f GB", mem_after / 1024))
   message("CNEFE processing complete")
 
-  return(addr)
+  list(data = addr, schools = schools)
 }
 
 

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -107,21 +107,21 @@ process_cnefe_state <- function(state_file, year, muni_ids, tract_centroids = NU
       substr(setor_code, 1, 2) %in% state_codes
     ]
 
-    # Schools come out of the same in-memory pass, so the state file is read once.
-    cleaned <- clean_cnefe10(
+    addr <- clean_cnefe10(
       cnefe10_file = state_file,
       muni_ids = state_muni_ids,
       tract_centroids = state_tract_centroids
     )
-    addr <- cleaned$data
-    schools <- cleaned$schools
   } else {
     addr <- clean_cnefe22(
       cnefe22_file = state_file,
       muni_ids = state_muni_ids
     )
-    schools <- get_cnefe_schools(addr)
   }
+
+  # Schools come out of the same in-memory pass, so the state file is read once.
+  schools <- get_cnefe_schools(addr)
+  message(sprintf("%s %s: extracted %s schools", year, state, format(nrow(schools), big.mark = ",")))
 
   list(
     st = aggregate_cnefe_coords(addr, "norm_street"),

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -120,7 +120,7 @@ process_cnefe_state <- function(state_file, year, muni_ids, tract_centroids = NU
       cnefe22_file = state_file,
       muni_ids = state_muni_ids
     )
-    schools <- get_cnefe22_schools(addr)
+    schools <- get_cnefe_schools(addr)
   }
 
   list(

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -111,8 +111,7 @@ process_cnefe_state <- function(state_file, year, muni_ids, tract_centroids = NU
     cleaned <- clean_cnefe10(
       cnefe10_file = state_file,
       muni_ids = state_muni_ids,
-      tract_centroids = state_tract_centroids,
-      extract_schools = TRUE
+      tract_centroids = state_tract_centroids
     )
     addr <- cleaned$data
     schools <- cleaned$schools


### PR DESCRIPTION
Closes #107. Closes #112.

## What this is for

`clean_cnefe10()` had a switch for whether to also pull out the school rows. Only one place calls the function, and it always asked for the schools — so the "no schools" half of the function had never actually run.

Removing it exposed two more things worth fixing in the same neighborhood: the school-extraction code was an exact copy of a helper the 2022 path already used, and the 2010 and 2022 cleaning functions returned different shapes for no reason. Both years now go through the same helper and return the same thing.

## Changes

- `clean_cnefe10()` loses the `extract_schools` argument. The unreachable tail (a bare `addr` return plus a duplicate memory message) is gone.
- `get_cnefe22_schools()` → `get_cnefe_schools()`. It was never 2022-specific — it only needs `especie_lab` and `desc`, which both years have. The 2010 code that repeated its three lines now calls it.
- `clean_cnefe10()` and `clean_cnefe22()` both return a bare address table. `process_cnefe_state()` extracts schools once, after the branch, so the `year` branch now covers only the real difference: 2010 needs tract centroids and a different file format.
- The school-count log line moved to the shared call site, so 2022 gets it too (previously only 2010 logged it).
- Dropped two comments that restated the code.

No behavior change. The 2010 school block and `get_cnefe22_schools()` were byte-identical.

## Verification

- `TAR_PROJECT=dev tar_make()` on `cnefe10_by_state`, `cnefe22_by_state`, `schools_cnefe10`, `schools_cnefe22`, `cnefe10_st`, `cnefe10_bairro`: both state targets rebuild to byte-identical output (436.83 kB and 577.54 kB, same as before the refactor) and every downstream target is then skipped as still-current.
- `Rscript tests/testthat.R`: `[ FAIL 3 | WARN 13 | SKIP 0 | PASS 201 ]`, identical to `master`. The 3 failures are pre-existing and unrelated — filed as #111.
- `air format --check` clean.

## Filed separately

- #111 — the 3 pre-existing test failures (non-UTF-8 locale mangles the `clean_inep` fixtures).

Review: `/simplify` (its reuse and altitude findings are what produced the shared helper and the unified return shape). Skipped the Codex layer — deletion-only, no behavior change, single consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)