### PR TITLE
Make the unit tests pass in a non-UTF-8 locale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,10 @@ transforms, matching core, panel identity); the rest are deferred to later
 tranches. Behavior-changing fail-loud tests land alongside their fixes in the
 cleanup work, not here.
 
+The fixtures carry accented Brazilian text, so the suite needs a UTF-8 locale —
+`tests/testthat/setup.R` sets one if the session starts in `C` and stops with a clear
+message if no UTF-8 locale is installed.
+
 #### Formatting gate (air)
 
 Formatting is handled by [air](https://posit-dev.github.io/air/), an idempotent

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -21,5 +21,21 @@ find_project_root <- function(start = getwd()) {
   }
 }
 
+# The fixtures carry accented Brazilian text (column names like "Município",
+# addresses like "Avenida São João"), and the cleaning functions under test are
+# the ones that de-accent it. In a non-UTF-8 locale R converts that text to the
+# native encoding as it parses each test file — accented characters become
+# literal "<U+00ED>" escapes — so the fixtures never reach the functions intact.
+# Establish the encoding the fixtures assume before any test file is parsed.
+if (!l10n_info()[["UTF-8"]]) {
+  for (locale in c("C.UTF-8", "en_US.UTF-8", "C.utf8")) {
+    suppressWarnings(Sys.setlocale("LC_CTYPE", locale))
+    if (l10n_info()[["UTF-8"]]) break
+  }
+  if (!l10n_info()[["UTF-8"]]) {
+    stop("The test suite needs a UTF-8 locale; none of C.UTF-8, en_US.UTF-8, C.utf8 are installed.")
+  }
+}
+
 testthat::local_edition(3)
 targets::tar_source(file.path(find_project_root(), "R"))


### PR DESCRIPTION
## What this is for

`Rscript tests/testthat.R` failed on any machine where R starts in the `C` locale (issue #111). The test fixtures contain accented Brazilian text, and the suite never said it needed a UTF-8 environment to read that text correctly. This makes the suite establish that requirement itself, so it passes anywhere.

## The mechanism

`LC_ALL=C Rscript tests/testthat.R` gave `[ FAIL 3 | WARN 13 | SKIP 0 | PASS 201 ]`, all three failures in `test-clean_inep.R` with `object 'municipio' not found`.

The fixture builds its table as `data.table("Município" = ..., "Endereço" = ...)`. Those are **argument names**, not strings — R always converts names to the native encoding, so in a `C` locale the column name became the literal `Munic<U+00ED>pio` and `clean_inep`'s `stri_trans_general(tolower(...), "Latin-ASCII")` never produced `municipio`. (String vectors survive intact; only names are converted, which is why passing the same text through `setnames()` works.)

The 13 warnings in `test-import_locais_local_id.R` were the same root cause reaching `janitor::make_clean_names()`.

## The fix

`tests/testthat/setup.R` sets a UTF-8 `LC_CTYPE` when the session starts without one, before any test file is parsed, and stops with a clear message if no UTF-8 locale is installed. Plus one line in CLAUDE.md next to the test commands.

Chosen over ASCII-escaping the fixtures because the escape route doesn't help — `"Município"` used as an argument name is still converted to native encoding at the call — and it would leave the `import_locais` warnings in place.

## Verification

`[ FAIL 0 | WARN 0 | SKIP 0 | PASS 210 ]` under all three of `LC_ALL=C`, `LC_ALL=C.UTF-8`, and the default locale. (201 → 210 because the three previously-failing tests now run their expectations.)

Also checked that the pipeline itself is not affected: reading accented data from a CSV, `normalize_address()` and `normalize_name()` return identical output in `C` and UTF-8 locales.

Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)