### PR TITLE
Keep dev-mode runs off the released output paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,9 +84,9 @@ output/**/*.R
 # Large data mapping files
 data/secao_local_2006_*_mapping.csv.gz
 
-# Generated reports
-reports/*.html
-reports/*_files/
+# Generated reports (reports/dev/ holds the dev-mode renders)
+reports/**/*.html
+reports/**/*_files/
 
 # Project backup folder
 project_backup/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,8 +133,9 @@ run time.
 - `output/geocoded_polling_stations.csv.gz`: Final geocoded coordinates
 - `output/panel_ids.csv.gz`: Panel identifiers linking stations across time
 
-Dev runs write the same filenames under `output/dev/`, so an AC/RR rebuild can
-never replace a released file.
+Dev runs write the same filenames under `output/dev/` (and their rendered
+reports under `reports/dev/`), so an AC/RR rebuild can never replace a released
+file.
 
 **AWS S3 Storage Architecture**:
 - Bucket: `geocode-br-polling-stations`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,8 +58,8 @@ Rscript tests/testthat.R
 
 # Slow dev-mode (AC/RR) end-to-end check: builds the pipeline fresh in dev mode
 # and asserts structural properties of the two final outputs (minutes, needs the
-# CNEFE/TSE inputs and real memory). NOTE: it writes the shared output/*.csv.gz
-# paths, overwriting any production outputs with AC/RR data.
+# CNEFE/TSE inputs and real memory). Its exports land in output/dev/, so the
+# released files under output/ are untouched.
 Rscript tests/integration/dev_pipeline_check.R
 ```
 
@@ -132,6 +132,9 @@ run time.
 **Outputs**:
 - `output/geocoded_polling_stations.csv.gz`: Final geocoded coordinates
 - `output/panel_ids.csv.gz`: Panel identifiers linking stations across time
+
+Dev runs write the same filenames under `output/dev/`, so an AC/RR rebuild can
+never replace a released file.
 
 **AWS S3 Storage Architecture**:
 - Bucket: `geocode-br-polling-stations`

--- a/R/string_match_diagnostics.R
+++ b/R/string_match_diagnostics.R
@@ -192,10 +192,10 @@ format_string_match_diagnostics <- function(diagnostics) {
 }
 
 # Print the match-quality report and write it alongside the released outputs.
-write_string_match_diagnostics <- function(string_match_diagnostics) {
+write_string_match_diagnostics <- function(string_match_diagnostics, dev_mode) {
   report_text <- format_string_match_diagnostics(string_match_diagnostics)
   cat(report_text)
-  dir.create("output", showWarnings = FALSE)
-  writeLines(report_text, "./output/string_match_diagnostics.txt")
-  "./output/string_match_diagnostics.txt"
+  path <- export_path("string_match_diagnostics.txt", dev_mode)
+  writeLines(report_text, path)
+  path
 }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -449,13 +449,19 @@ to_geocoded_export_schema <- function(geocoded_locais) {
   )]
 }
 
-# Destination for a written output, creating the directory. Dev runs cover only
-# AC/RR, so they write under output/dev/ and can never replace a released file.
-# Nested inside output/ because the worktree seed script clones that directory whole.
-export_path <- function(filename, dev_mode) {
-  dir <- if (dev_mode) "output/dev" else "output"
+# Directory the pipeline writes a given kind of output to, created if absent.
+# Dev runs cover only AC/RR, so they write to a dev/ subdirectory and can never
+# replace a released file. Nested inside the production directory because the
+# worktree seed script clones output/ and reports/ whole.
+run_output_dir <- function(base, dev_mode) {
+  dir <- if (dev_mode) file.path(base, "dev") else base
   dir.create(dir, showWarnings = FALSE, recursive = TRUE)
-  file.path(dir, filename)
+  dir
+}
+
+# Destination for one written output file.
+export_path <- function(filename, dev_mode) {
+  file.path(run_output_dir("output", dev_mode), filename)
 }
 
 # Write the published geocoded file and return its path. gates is a

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -449,26 +449,34 @@ to_geocoded_export_schema <- function(geocoded_locais) {
   )]
 }
 
+# Destination for a written output, creating the directory. Dev runs cover only
+# AC/RR, so they write under output/dev/ and can never replace a released file.
+# Nested inside output/ because the worktree seed script clones that directory whole.
+export_path <- function(filename, dev_mode) {
+  dir <- if (dev_mode) "output/dev" else "output"
+  dir.create(dir, showWarnings = FALSE, recursive = TRUE)
+  file.path(dir, filename)
+}
+
 # Write the published geocoded file and return its path. gates is a
 # dependency-only argument: passing the stage-validation targets makes the
 # write depend on them, so a validation failure stops the export.
-export_geocoded_locais <- function(geocoded_locais, gates) {
-  fwrite(
-    to_geocoded_export_schema(geocoded_locais),
-    "./output/geocoded_polling_stations.csv.gz"
-  )
-  "./output/geocoded_polling_stations.csv.gz"
+export_geocoded_locais <- function(geocoded_locais, gates, dev_mode) {
+  path <- export_path("geocoded_polling_stations.csv.gz", dev_mode)
+  fwrite(to_geocoded_export_schema(geocoded_locais), path)
+  path
 }
 
 # Write the published panel-ID file and return its path. gates as above.
-export_panel_ids <- function(panel_ids, gates) {
-  fwrite(panel_ids, "./output/panel_ids.csv.gz")
-  "./output/panel_ids.csv.gz"
+export_panel_ids <- function(panel_ids, gates, dev_mode) {
+  path <- export_path("panel_ids.csv.gz", dev_mode)
+  fwrite(panel_ids, path)
+  path
 }
 
 # Write the section-to-panel mapping and return its path.
-export_section_panel_mapping <- function(section_panel_mapping) {
-  dir.create("output", showWarnings = FALSE)
-  fwrite(section_panel_mapping, "./output/section_panel_mapping.csv.gz")
-  "./output/section_panel_mapping.csv.gz"
+export_section_panel_mapping <- function(section_panel_mapping, dev_mode) {
+  path <- export_path("section_panel_mapping.csv.gz", dev_mode)
+  fwrite(section_panel_mapping, path)
+  path
 }

--- a/_targets.R
+++ b/_targets.R
@@ -787,7 +787,7 @@ list(
   # Save diagnostics report
   tar_target(
     name = string_match_diagnostics_report,
-    command = write_string_match_diagnostics(string_match_diagnostics),
+    command = write_string_match_diagnostics(string_match_diagnostics, pipeline_config$dev_mode),
     format = "file",
     repository = "local"
   ),
@@ -925,11 +925,13 @@ list(
 
   # Each export writes its file and returns the path, so format = "file" rebuilds it
   # when the output is deleted; repository = "local" keeps the outputs off S3.
+  # dev_mode routes dev runs to output/dev/, off the released paths.
   tar_target(
     name = geocoded_export,
     command = export_geocoded_locais(
       geocoded_locais,
-      gates = list(validate_inputs, validate_model_data, validate_predictions, validate_geocoded_output)
+      gates = list(validate_inputs, validate_model_data, validate_predictions, validate_geocoded_output),
+      dev_mode = pipeline_config$dev_mode
     ),
     format = "file",
     repository = "local"
@@ -938,14 +940,15 @@ list(
     name = panelid_export,
     command = export_panel_ids(
       panel_ids,
-      gates = list(validate_inputs, validate_model_data, validate_predictions, validate_geocoded_output)
+      gates = list(validate_inputs, validate_model_data, validate_predictions, validate_geocoded_output),
+      dev_mode = pipeline_config$dev_mode
     ),
     format = "file",
     repository = "local"
   ),
   tar_target(
     name = section_panel_export,
-    command = export_section_panel_mapping(section_panel_mapping),
+    command = export_section_panel_mapping(section_panel_mapping, pipeline_config$dev_mode),
     format = "file",
     repository = "local"
   ),

--- a/_targets.R
+++ b/_targets.R
@@ -904,7 +904,7 @@ list(
   tar_render(
     name = evaluation_report,
     path = "reports/evaluation_report.qmd",
-    output_dir = "reports"
+    output_dir = run_output_dir("reports", DEV_MODE)
   ),
 
   # --- Final geocoding ---
@@ -987,10 +987,9 @@ list(
     cue = tar_cue(mode = "always")
   ),
   ## Sanity Check Report
-  # Sanity check report - generate if quarto file exists
   tar_render(
     name = sanity_check_report,
     path = "reports/polling_station_sanity_check.qmd",
-    output_dir = "reports"
+    output_dir = run_output_dir("reports", DEV_MODE)
   )
 )

--- a/tests/integration/dev_pipeline_check.R
+++ b/tests/integration/dev_pipeline_check.R
@@ -12,10 +12,8 @@
 ## Run with:  Rscript tests/integration/dev_pipeline_check.R
 ##
 ## Isolation: it sets TAR_PROJECT=dev, so all targets read/write the isolated dev
-## store (_targets_dev/). The export step still writes the shared output/*.csv.gz
-## paths, so this OVERWRITES any production output/ files with AC/RR data -- an
-## accepted limitation of the dev/prod split (the output paths are not yet
-## profile-isolated). Regenerate production outputs with a full `tar_make()`.
+## store (_targets_dev/) and the exports land in output/dev/. The released files
+## under output/ are untouched.
 ##
 ## Exit code is non-zero if any check fails, so it can later become a CI job.
 


### PR DESCRIPTION
## What this is for

A dev-mode run processes only two small states (AC and RR), but it wrote its
results to exactly the same filenames as a real production run. So running the
fast dev pipeline silently replaced the released national data files with
two-state data, with nothing in the filename to show it had happened. It had
already bitten twice. This PR gives dev runs their own directories, so they
cannot touch a released file.

Closes #83.

## Changes

- `run_output_dir(base, dev_mode)` in `R/utilities.R` picks `<base>` or
  `<base>/dev` and creates it. Dev subdirectories nest inside the production
  ones so the worktree seed script's snapshot list needs no new entry.
- The three export writers and the diagnostics writer route through
  `export_path()`, which sits on top of it; they take `dev_mode` from
  `pipeline_config$dev_mode`, the convention the rest of `_targets.R` uses for
  in-pipeline commands.
- The two `tar_render` targets take `output_dir = run_output_dir("reports", DEV_MODE)`,
  closing the same hazard for the rendered evaluation and sanity-check reports.
- `.gitignore`'s `reports/` patterns move to `**` form so they cover the nested
  directory. The `output/` patterns already did.

## The other half of #83

The issue's headline complaint — Gate 7 failing every dev run against a flat
national 85% coverage floor — was already fixed by eac89f2, which replaced the
floor with a per-vintage comparison against each vintage's own raw TSE
availability, scoped to the states present in `locais`. That fix was never
linked to this issue. Confirmed here: a dev-mode `release_gates` returns
`passed = TRUE`, `dev_mode = TRUE`, no failures, with the 2018 shortfall at
3.37 pt against a 5 pt slack. Only the export-path half was left, which is
what this PR does.

## Verification

Dev-mode rebuild of the affected targets:

- `geocoded_export`, `panelid_export`, `section_panel_export`, and
  `string_match_diagnostics_report` all resolve under `output/dev/`.
- `evaluation_report` and `sanity_check_report` render into `reports/dev/`.
- The files under `output/` keep their production content and `release_gates`
  passes.
- `Rscript tests/testthat.R`: 210 pass, 0 fail.

## Review

`/simplify` (four angles) plus a Codex pass, both over the branch diff. Reuse,
simplification, and efficiency came back clean. The altitude pass found the
`tar_render` gap — the exports were fixed but the two rendered reports still
shared a path between dev and production — which is the second commit here.
Codex found no actionable issue on the final diff.