### PR TITLE
Add field-decomposed similarity features to the match-selection model

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -13,28 +13,35 @@ library(stringr)
 GBM_LOG_OFFSET <- 1e-4
 
 # Melt one match table's per-candidate column groups -- coordinates, the whole-string
-# distance that selected the candidate, and the four field-decomposed similarities -- into
-# one row per candidate coordinate, named by `types` in column order. Every match table must
-# carry all seven groups; patterns() requires them to be the same length.
+# distance that selected the candidate, and the four field similarities -- into one row per
+# candidate coordinate. `types` maps each match table's column suffix (its names) to the
+# candidate type the model knows it by (its values).
+#
+# The columns are listed rather than matched by prefix because melt() pads a short group
+# with NA and assigns group members by position: one missing similarity column would
+# silently move another candidate's value onto the wrong row. Listing them makes it an error.
 melt_match_candidates <- function(matches, types) {
+  cols <- function(prefix) paste0(prefix, "_", names(types))
+  # Every candidate in the table must be named, or melt would quietly drop one. mindist_ is
+  # the one group every match function emits exactly once per candidate.
+  stopifnot(setequal(cols("mindist"), grep("^mindist_", names(matches), value = TRUE)))
+
   long <- melt(
     matches,
     id.vars = "local_id",
-    measure.vars = patterns(
-      long = "match_long_",
-      lat = "match_lat_",
-      mindist = "mindist_",
-      sim_name = "sim_name_",
-      sim_street = "sim_street_",
-      sim_bairro = "sim_bairro_",
-      sim_addr = "sim_addr_"
+    measure.vars = list(
+      long = cols("match_long"),
+      lat = cols("match_lat"),
+      mindist = cols("mindist"),
+      sim_name = cols("sim_name"),
+      sim_street = cols("sim_street"),
+      sim_bairro = cols("sim_bairro"),
+      sim_addr = cols("sim_addr")
     ),
     variable.name = "type",
     variable.factor = FALSE
   )
-  long[, type := types[as.integer(type)]]
-  # More coordinate column groups than names means the match table's columns changed.
-  stopifnot(!anyNA(long$type))
+  long[, type := unname(types)[as.integer(type)]]
   long[]
 }
 
@@ -49,9 +56,10 @@ geocodebr_candidates <- function(geocodebr_match) {
       type = "geocodebr",
       long = match_long_geocodebr,
       lat = match_lat_geocodebr,
-      # geocodebr resolves an address line, not separable name/street/bairro fields; the
-      # other three similarity columns are filled with NA by the rbindlist() that stacks
-      # these candidates with the melted ones, as precision_score already is.
+      # geocodebr resolves an address line, not separable name/street/bairro fields.
+      sim_name = NA_real_,
+      sim_street = NA_real_,
+      sim_bairro = NA_real_,
       sim_addr = sim_addr_geocodebr,
       precision_score = fcase(
         precisao_geocodebr == "numero"     , 3 ,
@@ -82,14 +90,23 @@ make_model_data <- function(
   # Each source names its coordinate columns after itself, so the tables are melted
   # separately and stacked afterwards rather than row-bound first.
   match_list <- list(
-    melt_match_candidates(cnefe10_stbairro_match, c("st_cnefe_2010", "bairro_cnefe_2010")),
-    melt_match_candidates(cnefe22_stbairro_match, c("st_cnefe_2022", "bairro_cnefe_2022")),
-    melt_match_candidates(schools_cnefe10_match, "schools_cnefe_name_2010"),
-    melt_match_candidates(schools_cnefe22_match, "schools_cnefe_name_2022"),
-    melt_match_candidates(inep_string_match, c("schools_inep_name", "schools_inep_addr")),
+    melt_match_candidates(
+      cnefe10_stbairro_match,
+      c(st = "st_cnefe_2010", bairro = "bairro_cnefe_2010")
+    ),
+    melt_match_candidates(
+      cnefe22_stbairro_match,
+      c(st = "st_cnefe_2022", bairro = "bairro_cnefe_2022")
+    ),
+    melt_match_candidates(schools_cnefe10_match, c(schools_cnefe = "schools_cnefe_name_2010")),
+    melt_match_candidates(schools_cnefe22_match, c(schools_cnefe = "schools_cnefe_name_2022")),
+    melt_match_candidates(
+      inep_string_match,
+      c(inep_name = "schools_inep_name", inep_addr = "schools_inep_addr")
+    ),
     melt_match_candidates(
       agrocnefe_stbairro_match,
-      c("st_agrocnefe_2017", "bairro_agrocnefe_2017")
+      c(st = "st_agrocnefe_2017", bairro = "bairro_agrocnefe_2017")
     ),
     geocodebr_candidates(geocodebr_match)
   )
@@ -125,10 +142,10 @@ make_model_data <- function(
       0
     )
   ]
-  # "sem numero" -- roughly a quarter of stations have no house number at all. normalize_address()
-  # already folds "s/n", "s n" and "sem numero" onto the token "sn". It flags informal or rural
-  # addressing, which is where street-median and municipality-level candidates are least precise.
-  addr_features[, addr_sn := fifelse(grepl("\\bsn\\b", normalized_addr), 1, 0)]
+  # The address gives no house number, which flags informal or rural addressing.
+  # normalize_address() folds "s/n" and "s n" onto the token "sn" but leaves "sem numero"
+  # spelled out, so both forms are matched here.
+  addr_features[, addr_sn := fifelse(grepl("\\b(sn|sem numero)\\b", normalized_addr), 1, 0)]
   addr_features <- addr_features[, .(
     local_id,
     centro,

--- a/R/model.R
+++ b/R/model.R
@@ -12,13 +12,23 @@ library(stringr)
 # shared by the forward transform and both inverse paths so they cannot drift apart.
 GBM_LOG_OFFSET <- 1e-4
 
-# Melt one match table's (match_long_*, match_lat_*, mindist_*) column triples into one row
-# per candidate coordinate, named by `types` in column order.
+# Melt one match table's per-candidate column groups -- coordinates, the whole-string
+# distance that selected the candidate, and the four field-decomposed similarities -- into
+# one row per candidate coordinate, named by `types` in column order. Every match table must
+# carry all seven groups; patterns() requires them to be the same length.
 melt_match_candidates <- function(matches, types) {
   long <- melt(
     matches,
     id.vars = "local_id",
-    measure.vars = patterns(long = "match_long_", lat = "match_lat_", mindist = "mindist_"),
+    measure.vars = patterns(
+      long = "match_long_",
+      lat = "match_lat_",
+      mindist = "mindist_",
+      sim_name = "sim_name_",
+      sim_street = "sim_street_",
+      sim_bairro = "sim_bairro_",
+      sim_addr = "sim_addr_"
+    ),
     variable.name = "type",
     variable.factor = FALSE
   )
@@ -39,6 +49,10 @@ geocodebr_candidates <- function(geocodebr_match) {
       type = "geocodebr",
       long = match_long_geocodebr,
       lat = match_lat_geocodebr,
+      # geocodebr resolves an address line, not separable name/street/bairro fields; the
+      # other three similarity columns are filled with NA by the rbindlist() that stacks
+      # these candidates with the melted ones, as precision_score already is.
+      sim_addr = sim_addr_geocodebr,
       precision_score = fcase(
         precisao_geocodebr == "numero"     , 3 ,
         precisao_geocodebr == "logradouro" , 2 ,
@@ -111,11 +125,16 @@ make_model_data <- function(
       0
     )
   ]
+  # "sem numero" -- roughly a quarter of stations have no house number at all. normalize_address()
+  # already folds "s/n", "s n" and "sem numero" onto the token "sn". It flags informal or rural
+  # addressing, which is where street-median and municipality-level candidates are least precise.
+  addr_features[, addr_sn := fifelse(grepl("\\bsn\\b", normalized_addr), 1, 0)]
   addr_features <- addr_features[, .(
     local_id,
     centro,
     zona_rural,
     school,
+    addr_sn,
     length_norm_name = nchar(norm_name),
     length_norm_addr = nchar(normalized_addr)
   )]

--- a/R/string_matching.R
+++ b/R/string_matching.R
@@ -58,6 +58,16 @@ match_strings <- function(query_strings, target_strings, normalize_by_length = T
   )
 }
 
+# Jaro-Winkler distance between two already-paired string vectors, for the per-field
+# similarity features the selection model consumes. Unlike match_strings() it chooses
+# nothing: the caller has already picked the reference row. It also never divides by
+# string length, so the features stay comparable across sources -- the length division in
+# match_strings() is a ranking quirk, not a distance. NA on either side (no match at all,
+# or a reference table without that field) yields NA, which lightgbm consumes directly.
+field_distance <- function(x, y) {
+  stringdist::stringdist(x, y, method = "jw")
+}
+
 match_inep_muni <- function(locais_muni, inep_muni) {
   # Match polling stations with INEP school data for a single municipality
 
@@ -77,17 +87,32 @@ match_inep_muni <- function(locais_muni, inep_muni) {
     inep_muni$norm_addr
   )
 
+  name_idx <- name_results$best_index
+  addr_idx <- addr_results$best_index
+
+  # Each candidate is scored on *both* INEP fields, not just the one it was selected on:
+  # a row that wins on the school name but whose address disagrees is now visible to the
+  # selection model. INEP has no separate street or neighborhood column -- `norm_addr` is a
+  # whole address line -- so sim_street and sim_bairro have nothing to compare against.
   # An unmatched station has best_index NA, and indexing by NA yields NA coordinates.
   data.table(
     local_id = locais_muni$local_id,
     match_inep_name = name_results$best_match,
     mindist_inep_name = name_results$min_dist,
-    match_long_inep_name = inep_muni$longitude[name_results$best_index],
-    match_lat_inep_name = inep_muni$latitude[name_results$best_index],
+    match_long_inep_name = inep_muni$longitude[name_idx],
+    match_lat_inep_name = inep_muni$latitude[name_idx],
+    sim_name_inep_name = field_distance(locais_muni$normalized_name, inep_muni$norm_school[name_idx]),
+    sim_street_inep_name = NA_real_,
+    sim_bairro_inep_name = NA_real_,
+    sim_addr_inep_name = field_distance(locais_muni$normalized_addr, inep_muni$norm_addr[name_idx]),
     match_inep_addr = addr_results$best_match,
     mindist_inep_addr = addr_results$min_dist,
-    match_long_inep_addr = inep_muni$longitude[addr_results$best_index],
-    match_lat_inep_addr = inep_muni$latitude[addr_results$best_index]
+    match_long_inep_addr = inep_muni$longitude[addr_idx],
+    match_lat_inep_addr = inep_muni$latitude[addr_idx],
+    sim_name_inep_addr = field_distance(locais_muni$normalized_name, inep_muni$norm_school[addr_idx]),
+    sim_street_inep_addr = NA_real_,
+    sim_bairro_inep_addr = NA_real_,
+    sim_addr_inep_addr = field_distance(locais_muni$normalized_addr, inep_muni$norm_addr[addr_idx])
   )
 }
 
@@ -104,13 +129,23 @@ match_schools_cnefe_muni <- function(locais_muni, schools_cnefe_muni) {
     schools_cnefe_muni$norm_desc
   )
 
+  idx <- name_results$best_index
+
+  # A CNEFE school row is a single establishment, so it carries a street and a
+  # neighborhood alongside its name. Scoring all three is the point of the decomposition:
+  # a school matched on name but sitting in the wrong bairro was previously indistinguishable
+  # from one in the right place. There is no whole address line to compare, hence sim_addr NA.
   data.table(
     local_id = locais_muni$local_id,
     match_schools_cnefe = name_results$best_match,
     mindist_schools_cnefe = name_results$min_dist,
-    match_long_schools_cnefe = schools_cnefe_muni$cnefe_long[name_results$best_index],
-    match_lat_schools_cnefe = schools_cnefe_muni$cnefe_lat[name_results$best_index],
-    match_bairro_schools_cnefe = schools_cnefe_muni$norm_bairro[name_results$best_index]
+    match_long_schools_cnefe = schools_cnefe_muni$cnefe_long[idx],
+    match_lat_schools_cnefe = schools_cnefe_muni$cnefe_lat[idx],
+    match_bairro_schools_cnefe = schools_cnefe_muni$norm_bairro[idx],
+    sim_name_schools_cnefe = field_distance(locais_muni$normalized_name, schools_cnefe_muni$norm_desc[idx]),
+    sim_street_schools_cnefe = field_distance(locais_muni$normalized_st, schools_cnefe_muni$norm_street[idx]),
+    sim_bairro_schools_cnefe = field_distance(locais_muni$normalized_bairro, schools_cnefe_muni$norm_bairro[idx]),
+    sim_addr_schools_cnefe = NA_real_
   )
 }
 
@@ -135,16 +170,31 @@ match_stbairro_muni <- function(locais_muni, st_muni, bairro_muni) {
     normalize_by_length = FALSE # Don't normalize for neighborhoods
   )
 
+  st_idx <- st_results$best_index
+  bairro_idx <- bairro_results$best_index
+
+  # These two references are coordinate medians over a whole street or neighborhood, so
+  # each knows exactly one field and the other three similarities have nothing to compare
+  # against. They are still emitted: melt_match_candidates() needs one column per
+  # (similarity field, candidate type) to line the candidates up.
   data.table(
     local_id = locais_muni$local_id,
     match_st = st_results$best_match,
     mindist_st = st_results$min_dist,
-    match_long_st = st_muni$long[st_results$best_index],
-    match_lat_st = st_muni$lat[st_results$best_index],
+    match_long_st = st_muni$long[st_idx],
+    match_lat_st = st_muni$lat[st_idx],
+    sim_name_st = NA_real_,
+    sim_street_st = field_distance(locais_muni$normalized_st, st_muni$norm_street[st_idx]),
+    sim_bairro_st = NA_real_,
+    sim_addr_st = NA_real_,
     match_bairro = bairro_results$best_match,
     mindist_bairro = bairro_results$min_dist,
-    match_long_bairro = bairro_muni$long[bairro_results$best_index],
-    match_lat_bairro = bairro_muni$lat[bairro_results$best_index]
+    match_long_bairro = bairro_muni$long[bairro_idx],
+    match_lat_bairro = bairro_muni$lat[bairro_idx],
+    sim_name_bairro = NA_real_,
+    sim_street_bairro = NA_real_,
+    sim_bairro_bairro = field_distance(locais_muni$normalized_bairro, bairro_muni$norm_bairro[bairro_idx]),
+    sim_addr_bairro = NA_real_
   )
 }
 
@@ -224,6 +274,17 @@ match_geocodebr_muni <- function(locais_muni) {
     !anyNA(geocoded_result$local_id)
   )
 
+  # geocodebr returns one formatted string, "STREET - BAIRRO, MUNICIPIO - UF", rather than
+  # structured fields, so the only field feature available is a whole-address-line
+  # similarity: the station's street+neighborhood against the found address with its
+  # municipality/state tail dropped. Municipality-precision rows resolved no street at all,
+  # so their address line is just the municipality and carries no similarity signal.
+  found_addr <- normalize_address(sub(",.*$", "", geocoded_result$endereco_encontrado))
+  found_addr[geocoded_result$precisao == "municipio"] <- NA_character_
+  station_addr <- locais_muni$normalized_addr[
+    match(geocoded_result$local_id, locais_muni$local_id)
+  ]
+
   # Create output in format consistent with other matching functions
   data.table(
     local_id = geocoded_result$local_id,
@@ -231,6 +292,7 @@ match_geocodebr_muni <- function(locais_muni) {
     mindist_geocodebr = 0, # geocodebr doesn't provide distance metric
     match_long_geocodebr = geocoded_result$lon,
     match_lat_geocodebr = geocoded_result$lat,
+    sim_addr_geocodebr = field_distance(station_addr, found_addr),
     precisao_geocodebr = geocoded_result$precisao,
     tipo_resultado_geocodebr = geocoded_result$tipo_resultado,
     contagem_cnefe_geocodebr = geocoded_result$contagem_cnefe

--- a/R/string_matching.R
+++ b/R/string_matching.R
@@ -58,12 +58,8 @@ match_strings <- function(query_strings, target_strings, normalize_by_length = T
   )
 }
 
-# Jaro-Winkler distance between two already-paired string vectors, for the per-field
-# similarity features the selection model consumes. Unlike match_strings() it chooses
-# nothing: the caller has already picked the reference row. It also never divides by
-# string length, so the features stay comparable across sources -- the length division in
-# match_strings() is a ranking quirk, not a distance. NA on either side (no match at all,
-# or a reference table without that field) yields NA, which lightgbm consumes directly.
+# Unnormalized Jaro-Winkler between paired strings, for the model's per-field similarity
+# features. NA on either side -- no match, or a reference table without that field -- gives NA.
 field_distance <- function(x, y) {
   stringdist::stringdist(x, y, method = "jw")
 }
@@ -90,10 +86,9 @@ match_inep_muni <- function(locais_muni, inep_muni) {
   name_idx <- name_results$best_index
   addr_idx <- addr_results$best_index
 
-  # Each candidate is scored on *both* INEP fields, not just the one it was selected on:
-  # a row that wins on the school name but whose address disagrees is now visible to the
-  # selection model. INEP has no separate street or neighborhood column -- `norm_addr` is a
-  # whole address line -- so sim_street and sim_bairro have nothing to compare against.
+  # Each candidate is scored on both INEP fields, not just the one it was selected on.
+  # INEP has no street or bairro column -- norm_addr is a whole address line -- so those
+  # two similarities are NA.
   # An unmatched station has best_index NA, and indexing by NA yields NA coordinates.
   data.table(
     local_id = locais_muni$local_id,
@@ -131,10 +126,8 @@ match_schools_cnefe_muni <- function(locais_muni, schools_cnefe_muni) {
 
   idx <- name_results$best_index
 
-  # A CNEFE school row is a single establishment, so it carries a street and a
-  # neighborhood alongside its name. Scoring all three is the point of the decomposition:
-  # a school matched on name but sitting in the wrong bairro was previously indistinguishable
-  # from one in the right place. There is no whole address line to compare, hence sim_addr NA.
+  # A CNEFE school row is one establishment, so it carries a street and a neighborhood
+  # alongside its name; all three are scored. No whole address line, so sim_addr is NA.
   data.table(
     local_id = locais_muni$local_id,
     match_schools_cnefe = name_results$best_match,
@@ -173,10 +166,10 @@ match_stbairro_muni <- function(locais_muni, st_muni, bairro_muni) {
   st_idx <- st_results$best_index
   bairro_idx <- bairro_results$best_index
 
-  # These two references are coordinate medians over a whole street or neighborhood, so
-  # each knows exactly one field and the other three similarities have nothing to compare
-  # against. They are still emitted: melt_match_candidates() needs one column per
-  # (similarity field, candidate type) to line the candidates up.
+  # These two references are coordinate medians over a whole street or neighborhood, so each
+  # knows exactly one field; the other three similarities are NA. sim_bairro_bairro repeats
+  # mindist_bairro, the one match run unnormalized, so the two are the same number.
+  # The NA columns are still emitted -- melt_match_candidates() explains why.
   data.table(
     local_id = locais_muni$local_id,
     match_st = st_results$best_match,
@@ -275,10 +268,8 @@ match_geocodebr_muni <- function(locais_muni) {
   )
 
   # geocodebr returns one formatted string, "STREET - BAIRRO, MUNICIPIO - UF", rather than
-  # structured fields, so the only field feature available is a whole-address-line
-  # similarity: the station's street+neighborhood against the found address with its
-  # municipality/state tail dropped. Municipality-precision rows resolved no street at all,
-  # so their address line is just the municipality and carries no similarity signal.
+  # structured fields, so the only field feature available is a whole-address-line similarity.
+  # Municipality-precision rows resolved no street, leaving nothing to compare.
   found_addr <- normalize_address(sub(",.*$", "", geocoded_result$endereco_encontrado))
   found_addr[geocoded_result$precisao == "municipio"] <- NA_character_
   station_addr <- locais_muni$normalized_addr[

--- a/doc/geocoding_procedure.qmd
+++ b/doc/geocoding_procedure.qmd
@@ -77,11 +77,13 @@ The general approach is a follows:
 
 3.  Find the "medioid" (i.e. the median point) for all unique streets and neighborhoods in the CNEFE datasets.
 
-4.  Compute the normalized Levenshtein string distance between polling station name and the names of schools in the INEP and  CNEFE data in the same municipality as the polling station.
+4.  Compute the length-normalized Jaro-Winkler string distance between polling station name and the names of schools in the INEP and  CNEFE data in the same municipality as the polling station.
 
 5.  Compute the string distance between the address of polling stations and address of schools in INPE and  CNEFE data.
 
 6.  Compute the string distance between the street name and neighborhood name of the polling station and street and neighborhood names from the CNEFE datasets.
+
+7.  For each candidate produced by steps 4--6, compute a *further* string distance for every address component the matched reference record happens to carry, not only the component the match was made on: school name, street, neighborhood, and (where the source stores a single unsplit address line) the whole address. A CNEFE school record, for example, is a single establishment and so carries a street and a neighborhood alongside its name; scoring all three reveals a school whose name matches perfectly but which sits in the wrong neighborhood. Where a source has no such field --- the street and neighborhood reference tables are coordinate medians over a whole street or neighborhood, and know only the one field they are keyed on --- the corresponding distance is missing, which the boosted tree handles natively.
 
 [^3]: We remove common, but uninformative words, such as "povoado" and "localidade". We standardize common street abbreviations such as replacing "Av" with "Avenida". Finally, for polling station names, we remove words most common in school names, such as "unidade escolar" and "colegio estadual". These are very common, yet not used consistently and as a result, are relatively uninformative. We found that removing them improves matching performance.
 
@@ -93,11 +95,13 @@ After string matching, we use a boosted tree model to predict the distance betwe
 We treat the coordinates provided by the election authorities as the "ground truth".
 This distance is modeled as a function of the following set of covariates:
 
--   Normalized Levenshtein string distance.
+-   Length-normalized Jaro-Winkler string distance of the match that produced the candidate.
+-   Four per-component string distances between the polling station and the matched reference record: school name, street, neighborhood, and whole address line (step 7 above). Each is missing when the source carries no such field.
 -   Coordinate data source
 -   Indicator for whether the address mentions the city center ("centro")
 -   Indicator for whether the address mentions being in the countryside (includes the word "rural")
 -   Indicator for whether the address mentions a school
+-   Indicator for whether the address gives no house number ("s/n"), which is true of roughly a quarter of polling stations and signals informal or rural addressing
 -   Log of municipal population
 -   Proportion of the population classified as rural
 -   Area of the municipality
@@ -154,7 +158,7 @@ geocoded_locais <- inner_join(locais, best_prediction) |>
 ```
 
 To illustrate the string matching procedure, the table below shows the string matching procedure for one polling station where the coordinates are known.
-"String distance" is the normalized Levenshtein string distance between the address component and its potential match.
+"String distance" is the length-normalized Jaro-Winkler string distance between the address component and its potential match.
 "Predicted distance" is the distance from the truth predicted by the gradient-boosted tree model.
 The blue row shows the selected match, which is the potential match with the smallest predicted distance.
 The last column labeled "Error (km)" is the difference between the known geocoded coordinates and the coordinates from the selected match.

--- a/tests/testthat/test-match_inep_muni.R
+++ b/tests/testthat/test-match_inep_muni.R
@@ -55,6 +55,32 @@ test_that("match_inep_muni leaves a non-matching station fully NA", {
   expect_true(is.na(r3$match_long_inep_addr))
 })
 
+test_that("match_inep_muni scores both INEP fields on each candidate", {
+  out <- match_inep_muni(make_locais(), make_inep())
+  r1 <- out[local_id == 1L]
+  # Station 1 was selected on the school name, but the address of that same INEP row is
+  # scored too: "rua a" vs "rua x" disagrees, which the name distance alone cannot show.
+  expect_equal(r1$sim_name_inep_name, 0)
+  expect_gt(r1$sim_addr_inep_name, 0)
+  # INEP has no separate street or neighbourhood column.
+  expect_true(is.na(r1$sim_street_inep_name))
+  expect_true(is.na(r1$sim_bairro_inep_name))
+
+  r2 <- out[local_id == 2L]
+  # Selected on address; the school name of that row is scored as well.
+  expect_equal(r2$sim_addr_inep_addr, 0)
+  expect_gt(r2$sim_name_inep_addr, 0)
+})
+
+test_that("match_inep_muni leaves field similarities NA when nothing was selected", {
+  out <- match_inep_muni(make_locais(), make_inep())
+  r3 <- out[local_id == 3L]
+  expect_true(is.na(r3$sim_name_inep_name))
+  expect_true(is.na(r3$sim_addr_inep_name))
+  expect_true(is.na(r3$sim_name_inep_addr))
+  expect_true(is.na(r3$sim_addr_inep_addr))
+})
+
 test_that("match_inep_muni returns NULL when there are no INEP rows", {
   expect_null(match_inep_muni(make_locais(), make_inep()[0]))
 })

--- a/tests/testthat/test-match_inep_muni.R
+++ b/tests/testthat/test-match_inep_muni.R
@@ -72,15 +72,6 @@ test_that("match_inep_muni scores both INEP fields on each candidate", {
   expect_gt(r2$sim_name_inep_addr, 0)
 })
 
-test_that("match_inep_muni leaves field similarities NA when nothing was selected", {
-  out <- match_inep_muni(make_locais(), make_inep())
-  r3 <- out[local_id == 3L]
-  expect_true(is.na(r3$sim_name_inep_name))
-  expect_true(is.na(r3$sim_addr_inep_name))
-  expect_true(is.na(r3$sim_name_inep_addr))
-  expect_true(is.na(r3$sim_addr_inep_addr))
-})
-
 test_that("match_inep_muni returns NULL when there are no INEP rows", {
   expect_null(match_inep_muni(make_locais(), make_inep()[0]))
 })

--- a/tests/testthat/test-match_schools_cnefe_muni.R
+++ b/tests/testthat/test-match_schools_cnefe_muni.R
@@ -1,12 +1,14 @@
 ## Spec tests for match_schools_cnefe_muni() (R/string_matching.R).
 ## Matches polling-station names against CNEFE school descriptions, attaching the
-## CNEFE coordinates and neighbourhood of the best name match. Empty CNEFE input
-## returns NULL.
+## CNEFE coordinates and neighbourhood of the best name match, plus a similarity
+## per address field. Empty CNEFE input returns NULL.
 
 make_locais <- function() {
   data.table::data.table(
     local_id = c(1L, 2L),
-    normalized_name = c("escola central", "qqq nomatch")
+    normalized_name = c("escola central", "qqq nomatch"),
+    normalized_st = c("rua das flores", "rua das flores"),
+    normalized_bairro = c("centro", "centro")
   )
 }
 
@@ -15,6 +17,7 @@ make_schools_cnefe <- function() {
     norm_desc = c("escola central", "escola norte"),
     cnefe_long = c(-60, -61),
     cnefe_lat = c(-9, -8),
+    norm_street = c("rua das flores", "avenida norte"),
     norm_bairro = c("centro", "norte")
   )
 }
@@ -30,12 +33,39 @@ test_that("match_schools_cnefe_muni attaches coordinates and bairro of the best 
   expect_equal(r1$match_bairro_schools_cnefe, "centro")
 })
 
+test_that("match_schools_cnefe_muni scores name, street and bairro of the selected row", {
+  out <- match_schools_cnefe_muni(make_locais(), make_schools_cnefe())
+  r1 <- out[local_id == 1L]
+  # Station 1 agrees with the selected school on all three fields.
+  expect_equal(r1$sim_name_schools_cnefe, 0)
+  expect_equal(r1$sim_street_schools_cnefe, 0)
+  expect_equal(r1$sim_bairro_schools_cnefe, 0)
+  # CNEFE school rows carry no whole address line to compare.
+  expect_true(is.na(r1$sim_addr_schools_cnefe))
+})
+
+test_that("match_schools_cnefe_muni exposes a name match that disagrees on bairro", {
+  locais <- make_locais()
+  locais[local_id == 1L, normalized_bairro := "vila nova"]
+  out <- match_schools_cnefe_muni(locais, make_schools_cnefe())
+  r1 <- out[local_id == 1L]
+  # The name still matches perfectly, so the whole-string distance sees nothing wrong;
+  # only the decomposed bairro similarity records the disagreement.
+  expect_equal(r1$mindist_schools_cnefe, 0)
+  expect_equal(r1$sim_name_schools_cnefe, 0)
+  expect_gt(r1$sim_bairro_schools_cnefe, 0)
+})
+
 test_that("match_schools_cnefe_muni leaves a non-matching station NA", {
   out <- match_schools_cnefe_muni(make_locais(), make_schools_cnefe())
   r2 <- out[local_id == 2L]
   expect_true(is.na(r2$match_schools_cnefe))
   expect_true(is.na(r2$match_long_schools_cnefe))
   expect_true(is.na(r2$match_bairro_schools_cnefe))
+  # No selected reference row means no field to compare against.
+  expect_true(is.na(r2$sim_name_schools_cnefe))
+  expect_true(is.na(r2$sim_street_schools_cnefe))
+  expect_true(is.na(r2$sim_bairro_schools_cnefe))
 })
 
 test_that("match_schools_cnefe_muni returns NULL when there are no CNEFE rows", {

--- a/tests/testthat/test-match_stbairro_muni.R
+++ b/tests/testthat/test-match_stbairro_muni.R
@@ -47,6 +47,21 @@ test_that("match_stbairro_muni leaves a non-matching station NA", {
   expect_true(is.na(r2$match_bairro))
 })
 
+test_that("match_stbairro_muni scores only the one field each aggregate knows", {
+  out <- match_stbairro_muni(make_locais(), make_st(), make_bairro())
+  r1 <- out[local_id == 1L]
+  expect_equal(r1$sim_street_st, 0)
+  expect_equal(r1$sim_bairro_bairro, 0)
+  # Street and neighbourhood aggregates are coordinate medians over a whole street or
+  # neighbourhood, so they carry no name, no address line, and not the other's field.
+  expect_true(is.na(r1$sim_name_st))
+  expect_true(is.na(r1$sim_bairro_st))
+  expect_true(is.na(r1$sim_addr_st))
+  expect_true(is.na(r1$sim_name_bairro))
+  expect_true(is.na(r1$sim_street_bairro))
+  expect_true(is.na(r1$sim_addr_bairro))
+})
+
 test_that("match_stbairro_muni returns NULL when there are no street rows", {
   expect_null(match_stbairro_muni(make_locais(), make_st()[0], make_bairro()))
 })

--- a/tests/testthat/test-match_stbairro_muni.R
+++ b/tests/testthat/test-match_stbairro_muni.R
@@ -47,19 +47,11 @@ test_that("match_stbairro_muni leaves a non-matching station NA", {
   expect_true(is.na(r2$match_bairro))
 })
 
-test_that("match_stbairro_muni scores only the one field each aggregate knows", {
+test_that("match_stbairro_muni scores the one field each aggregate knows", {
   out <- match_stbairro_muni(make_locais(), make_st(), make_bairro())
   r1 <- out[local_id == 1L]
   expect_equal(r1$sim_street_st, 0)
   expect_equal(r1$sim_bairro_bairro, 0)
-  # Street and neighbourhood aggregates are coordinate medians over a whole street or
-  # neighbourhood, so they carry no name, no address line, and not the other's field.
-  expect_true(is.na(r1$sim_name_st))
-  expect_true(is.na(r1$sim_bairro_st))
-  expect_true(is.na(r1$sim_addr_st))
-  expect_true(is.na(r1$sim_name_bairro))
-  expect_true(is.na(r1$sim_street_bairro))
-  expect_true(is.na(r1$sim_addr_bairro))
 })
 
 test_that("match_stbairro_muni returns NULL when there are no street rows", {

--- a/tests/testthat/test-melt_match_candidates.R
+++ b/tests/testthat/test-melt_match_candidates.R
@@ -1,0 +1,48 @@
+## Spec tests for melt_match_candidates() (R/model.R).
+## Turns one match table's per-candidate column groups into one row per candidate
+## coordinate. The contract that matters is alignment: every group -- coordinates, the
+## whole-string distance, and the four field similarities -- must be split by candidate
+## in the same order, so a value never lands on the wrong candidate type.
+
+make_two_candidate_matches <- function() {
+  data.table::data.table(
+    local_id = c(1L, 2L),
+    match_long_st = c(-60, -61),
+    match_lat_st = c(-9, -8),
+    mindist_st = c(0.1, 0.2),
+    sim_name_st = NA_real_,
+    sim_street_st = c(0.11, 0.21),
+    sim_bairro_st = NA_real_,
+    sim_addr_st = NA_real_,
+    match_long_bairro = c(-70, -71),
+    match_lat_bairro = c(-19, -18),
+    mindist_bairro = c(0.3, 0.4),
+    sim_name_bairro = NA_real_,
+    sim_street_bairro = NA_real_,
+    sim_bairro_bairro = c(0.31, 0.41),
+    sim_addr_bairro = NA_real_
+  )
+}
+
+test_that("melt_match_candidates keeps every column group aligned to its candidate type", {
+  long <- melt_match_candidates(make_two_candidate_matches(), c("street", "neighbourhood"))
+  expect_equal(nrow(long), 4L)
+
+  st <- long[type == "street"][order(local_id)]
+  expect_equal(st$long, c(-60, -61))
+  expect_equal(st$mindist, c(0.1, 0.2))
+  expect_equal(st$sim_street, c(0.11, 0.21))
+  expect_true(all(is.na(st$sim_bairro)))
+
+  bairro <- long[type == "neighbourhood"][order(local_id)]
+  expect_equal(bairro$long, c(-70, -71))
+  expect_equal(bairro$mindist, c(0.3, 0.4))
+  expect_equal(bairro$sim_bairro, c(0.31, 0.41))
+  expect_true(all(is.na(bairro$sim_street)))
+})
+
+test_that("melt_match_candidates fails when a candidate type is unnamed", {
+  # More column groups than names means the match table gained a candidate type without
+  # the model being told about it -- a silent mislabel, so it must error.
+  expect_error(melt_match_candidates(make_two_candidate_matches(), "street"))
+})

--- a/tests/testthat/test-melt_match_candidates.R
+++ b/tests/testthat/test-melt_match_candidates.R
@@ -1,8 +1,9 @@
 ## Spec tests for melt_match_candidates() (R/model.R).
 ## Turns one match table's per-candidate column groups into one row per candidate
-## coordinate. The contract that matters is alignment: every group -- coordinates, the
-## whole-string distance, and the four field similarities -- must be split by candidate
-## in the same order, so a value never lands on the wrong candidate type.
+## coordinate. The contract that matters is alignment: every group must be split by
+## candidate in the same order, so a value never lands on the wrong candidate type.
+## Both failure modes below are silent if the columns are matched by prefix instead of
+## named, because melt() pads a short group with NA and assigns members by position.
 
 make_two_candidate_matches <- function() {
   data.table::data.table(
@@ -24,8 +25,10 @@ make_two_candidate_matches <- function() {
   )
 }
 
+TYPES <- c(st = "street", bairro = "neighbourhood")
+
 test_that("melt_match_candidates keeps every column group aligned to its candidate type", {
-  long <- melt_match_candidates(make_two_candidate_matches(), c("street", "neighbourhood"))
+  long <- melt_match_candidates(make_two_candidate_matches(), TYPES)
   expect_equal(nrow(long), 4L)
 
   st <- long[type == "street"][order(local_id)]
@@ -41,8 +44,16 @@ test_that("melt_match_candidates keeps every column group aligned to its candida
   expect_true(all(is.na(bairro$sim_street)))
 })
 
+test_that("melt_match_candidates fails when a similarity column is missing", {
+  # Without sim_bairro_st, the neighbourhood's 0.31 would otherwise shift onto the street
+  # candidate: the group is padded from the left, not matched to its candidate.
+  matches <- make_two_candidate_matches()
+  matches[, sim_bairro_st := NULL]
+  expect_error(melt_match_candidates(matches, TYPES))
+})
+
 test_that("melt_match_candidates fails when a candidate type is unnamed", {
-  # More column groups than names means the match table gained a candidate type without
-  # the model being told about it -- a silent mislabel, so it must error.
-  expect_error(melt_match_candidates(make_two_candidate_matches(), "street"))
+  # A match table that gained a candidate the model was not told about would otherwise be
+  # silently dropped rather than mislabelled.
+  expect_error(melt_match_candidates(make_two_candidate_matches(), c(st = "street")))
 })


### PR DESCRIPTION
## What this is for

The pipeline proposes several candidate coordinates for each polling station, and a boosted tree picks the best one. Until now the tree saw only **one** number describing each candidate: the string distance of whatever single field the match was made on. So a CNEFE school record whose *name* matched perfectly, but which sits in a completely different neighborhood, looked exactly as good as one in the right place — the neighborhood was never compared.

This PR compares every address component the matched record actually carries, and hands each one to the model separately.

Closes #39 (wave 1b of the [methodology roadmap](https://github.com/fdhidalgo/geocode_br_polling_stations/blob/master/docs/specs/2026-07-methodology-roadmap.md)).

## What changed

Each `match_*_muni()` function in `R/string_matching.R` now scores the reference row it selected on each component that row has, and `R/model.R` melts them through as four features:

| candidate source | `sim_name` | `sim_street` | `sim_bairro` | `sim_addr` |
|---|---|---|---|---|
| INEP (name- and address-matched) | ✓ | – | – | ✓ |
| CNEFE schools 2010 / 2022 | ✓ | ✓ | ✓ | – |
| CNEFE / Agro street medians | – | ✓ | – | – |
| CNEFE / Agro neighborhood medians | – | – | ✓ | – |
| geocodebr | – | – | – | ✓ |

Where a source has no such field the similarity is `NA`, which lightgbm consumes natively. The street and neighborhood references are coordinate medians over a whole street or neighborhood, so they genuinely know only the one field they are keyed on.

The whole-string `mindist` stays. It is the competitive signal of *which* reference row won, which the per-field scores do not reproduce.

## The house-number component, and why it is not a string distance

The issue names house number as the fourth component. It is not implemented as one, for two reasons:

- **Coverage.** No reference table the model sees carries a house number — the street and neighborhood tables are aggregates. Only raw CNEFE school rows have one, and sampling them gives 31% (AC) / 46% (AL) populated, against 26–31% of polling stations whose address is explicitly `s/n` (*sem número*) and 33% with no digit at all. Joint coverage lands under ~5% of model rows, on 2 of 11 candidate types. Extracting the station-side number also needs a real parser, not a regex — the first data row reads `AV. 12 DE OUTUBRO N 3221 - FONE 069-3541-7112`.
- **Metric.** Edit distance on digits is the wrong measurement regardless: `"100"` vs `"900"` is distance 1, `"123"` vs `"1234"` is distance 1.

It is replaced by **`addr_sn`**, a station-level indicator that the address gives no house number at all (25% of stations). That is the signal a house number actually carries here — it flags informal and rural addressing, where street-median and municipality-level candidates are least precise. It needs no reference data and no CNEFE schema change.

Structured house-number handling belongs with geocodebr's `numero` field, which is wave 1a's scope.

## Measurement

Dev slice (AC/RR, 3,702 covered stations), each arm tuning its own hyperparameters over the same candidate set and fold assignment — `mtry` is feature-count dependent, so they cannot be shared:

| | baseline | with features | Δ |
|---|---|---|---|
| within 100 m | 62.4% | **67.6%** | +5.2 pp |
| within 500 m | 73.6% | **77.9%** | +4.3 pp |
| within 1 km | 78.3% | **82.5%** | +4.2 pp |
| p90 error | 16.8 km | **7.4 km** | −9.4 km |
| median error | 35.7 m | **29.3 m** | −6.4 m |

The four similarities take ~57% of the fitted model's gain (`sim_name` alone 39%) against `mindist`'s 13%. `addr_sn` contributes almost nothing on this slice (0.2%), which is weak evidence either way at AC/RR scale.

**This is not the #39 gate measurement.** That needs a production run against the frozen v0.15 baseline on the evaluation harness. This is a controlled dev-slice check that the change helps rather than hurts.

## Review

Both layers ran (the diff changes an analysis pipeline's shape). Codex found nothing. `/simplify` — run against `paper-code/references/standards.md` as the governing standard — surfaced one thing worth its own commit:

**`melt()`'s `patterns()` does not require equal-length column groups.** It pads a short group with `NA` and assigns members *by position*, so a match table missing one similarity column silently shifts another candidate's value onto the wrong candidate type. My original comment asserted the opposite. Three reviewers independently disproved it; I reproduced it before acting:

```
   local_id   type  long  simx
1:        1      1    10  0.99   <- simx_bairro's value, on the st row
2:        1      2    20    NA
```

`melt_match_candidates()` now takes a map from column suffix to candidate type and lists its columns explicitly, so a missing column errors and ordering keys to the map rather than to column position. An assertion catches the opposite slip (a candidate in the table but not in the map, which would be dropped rather than mislabelled). Both are now tested. `model_data` rebuilds to an identical hash, so this changed no output.

Also applied: `addr_sn`'s comment claimed a `normalize_address()` rule that does not exist (it folds `s/n` and `s n`, not `sem numero`) — the indicator now matches both forms; `geocodebr_candidates()` states its absent similarities explicitly instead of leaning on `rbindlist(fill = TRUE)`; design-rationale comments and two tests that asserted `NA_real_` is `NA` were cut.

Not taken: returning the undivided distance from `match_strings()` to avoid recomputing five of the similarities. Measured at ~15 s of CPU across the entire production run — the machinery outweighs it. `sim_bairro_bairro` duplicates `mindist_bairro` exactly (bairro matching is the one unnormalized match); kept, so `sim_bairro` means the same thing on every row, with the redundancy noted in the code.

## Verification

- `Rscript tests/testthat.R` — 239 pass
- Full dev-mode pipeline (`TAR_PROJECT=dev`) green end to end, 125 targets, no new warnings
- `doc/geocoding_procedure` updated in lockstep (it also described the metric as Levenshtein; the code has always used Jaro-Winkler, corrected in the passages touched)

Filed #123 for the unrelated dead `match_bairro_schools_cnefe` column noticed in passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)