### PR TITLE
Key the section-panel mapping on the municipality

### DIFF
--- a/R/panel_creation.R
+++ b/R/panel_creation.R
@@ -691,7 +691,19 @@ create_section_panel_mapping <- function(secc_loc_map, geocoded_locais, panel_id
 
   final_clean <- final_mapping[!is.na(panel_id)]
 
-  output_columns <- c("nr_secao", "nr_zona", "nr_local_votacao", "ano", "estado_abrev", "nm_localidade", "panel_id")
+  # cd_localidade_tse is part of the section key, not decoration: an electoral zone spans
+  # several municipalities (RS zona 20 covers 14) and section numbers restart within each,
+  # so (nr_secao, nr_zona, ano, estado_abrev) alone points at the wrong municipality's panel.
+  output_columns <- c(
+    "nr_secao",
+    "nr_zona",
+    "nr_local_votacao",
+    "ano",
+    "estado_abrev",
+    "cd_localidade_tse",
+    "nm_localidade",
+    "panel_id"
+  )
   missing_cols <- setdiff(output_columns, colnames(final_clean))
   if (length(missing_cols) > 0) {
     stop(
@@ -700,18 +712,22 @@ create_section_panel_mapping <- function(secc_loc_map, geocoded_locais, panel_id
     )
   }
 
-  result <- final_clean[, .SD, .SDcols = output_columns]
+  # The source lists some stations twice under different name/address spellings; those rows
+  # are identical once the descriptive columns are dropped.
+  result <- unique(final_clean[, .SD, .SDcols = output_columns])
 
   cat("Validating final mapping...\n")
 
-  # An election section belongs to exactly one polling place in a given year.
-  duplicate_sections <- result[, .N, by = .(nr_secao, nr_zona, ano, estado_abrev)][N > 1]
-  if (nrow(duplicate_sections) > 0) {
-    stop(
-      "create_section_panel_mapping(): ",
-      nrow(duplicate_sections),
-      " duplicate (nr_secao, nr_zona, ano, estado_abrev) keys in the section-panel mapping."
-    )
+  section_key <- c("nr_secao", "nr_zona", "ano", "estado_abrev", "cd_localidade_tse")
+
+  # A section votes at one polling place per election, but the source carries no round
+  # column, so a section relocated between rounds appears twice with nothing to say which
+  # assignment belongs to which round. Drop those rather than publish two panels for one
+  # section; recovering them needs nr_turno in secc_loc_map.
+  ambiguous <- result[, .N, by = section_key][N > 1][, ..section_key]
+  if (nrow(ambiguous) > 0) {
+    cat("  Dropping", nrow(ambiguous), "sections listed at more than one polling place\n")
+    result <- result[!ambiguous, on = section_key]
   }
 
   panel_distribution <- result[, .N, by = panel_id][order(-N)]
@@ -724,7 +740,6 @@ create_section_panel_mapping <- function(secc_loc_map, geocoded_locais, panel_id
 
   cat("\nFinal mapping summary:\n")
   cat("  Total records:", format(nrow(result), big.mark = ","), "\n")
-  cat("  Unique sections:", format(nrow(result[, .(nr_secao, nr_zona, ano, estado_abrev)]), big.mark = ","), "\n")
   cat("  Unique panels:", format(length(unique(result$panel_id)), big.mark = ","), "\n")
   cat("  Years covered:", paste(sort(unique(result$ano)), collapse = ", "), "\n")
   cat("  States covered:", length(unique(result$estado_abrev)), "\n")

--- a/R/panel_creation.R
+++ b/R/panel_creation.R
@@ -691,9 +691,8 @@ create_section_panel_mapping <- function(secc_loc_map, geocoded_locais, panel_id
 
   final_clean <- final_mapping[!is.na(panel_id)]
 
-  # cd_localidade_tse is part of the section key, not decoration: an electoral zone spans
-  # several municipalities (RS zona 20 covers 14) and section numbers restart within each,
-  # so (nr_secao, nr_zona, ano, estado_abrev) alone points at the wrong municipality's panel.
+  # cd_localidade_tse ships too, for the same reason it is in the key above: RS zona 20
+  # alone spans 14 municipalities, each restarting its section numbers from 1.
   output_columns <- c(
     "nr_secao",
     "nr_zona",
@@ -714,7 +713,7 @@ create_section_panel_mapping <- function(secc_loc_map, geocoded_locais, panel_id
 
   # The source lists some stations twice under different name/address spellings; those rows
   # are identical once the descriptive columns are dropped.
-  result <- unique(final_clean[, .SD, .SDcols = output_columns])
+  result <- unique(final_clean[, ..output_columns])
 
   cat("Validating final mapping...\n")
 
@@ -722,11 +721,22 @@ create_section_panel_mapping <- function(secc_loc_map, geocoded_locais, panel_id
 
   # A section votes at one polling place per election, but the source carries no round
   # column, so a section relocated between rounds appears twice with nothing to say which
-  # assignment belongs to which round. Drop those rather than publish two panels for one
-  # section; recovering them needs nr_turno in secc_loc_map.
+  # assignment belongs to which round. Publishing two panels for one section is worse than
+  # publishing neither, so these are dropped -- but only where the defect is known to live:
+  # RS 2012, 39 sections out of 4.33M rows. Ambiguity anywhere else is a new problem.
   ambiguous <- result[, .N, by = section_key][N > 1][, ..section_key]
   if (nrow(ambiguous) > 0) {
-    cat("  Dropping", nrow(ambiguous), "sections listed at more than one polling place\n")
+    unexpected <- ambiguous[!(estado_abrev == "RS" & ano == 2012)]
+    if (nrow(unexpected) > 0) {
+      stop(
+        "create_section_panel_mapping(): ",
+        nrow(unexpected),
+        " sections outside RS 2012 sit at more than one polling place; ",
+        "first: ",
+        paste(unexpected[1], collapse = " ")
+      )
+    }
+    cat("  Dropping", nrow(ambiguous), "RS 2012 sections listed at more than one polling place\n")
     result <- result[!ambiguous, on = section_key]
   }
 


### PR DESCRIPTION
## What this is for

A full pipeline run died with 17,900 duplicate keys in the section-to-panel mapping. The check that caught it was right to fire, but for a reason nobody expected: the file we publish can't actually be joined the way it advertises.

The mapping lets users attach panel IDs to section-level election results. It ships `nr_secao`, `nr_zona`, `ano`, and `estado_abrev` — so that reads as the key. It isn't. An electoral zone spans several municipalities and section numbers restart in each one (RS zona 20 covers 14 municipalities), so those four columns can point at a section in the wrong town. Anyone who joined on them got the wrong municipality's panel for those rows.

This adds the municipality to both the published columns and the uniqueness check, which is what the data always required.

## Why it took a full run to find

The check started as a printed warning, became `warning()`, and was promoted to `stop()` in `4595bd2` — but it was only ever exercised in dev mode. Dev mode is AC/RR, and **those two states have zero duplicate keys**. Production was the first thing to see the other 25.

## What the 17,900 actually were

The joins were never the problem — verified that no location key carries more than one `local_id`, and `local_id` is unique in `panel_ids`. Every duplicate was already in the input file.

| | Groups | Cause | Handling |
|---|---|---|---|
| Missing municipality | 17,133 | Zones span municipalities; section numbers restart | Fixed by the key change |
| Redundant source rows | 728 | Same station listed twice under different name/address spellings | `unique()` — identical once descriptive columns drop |
| Genuinely ambiguous | 39 | One section at two polling places, all RS 2012 | Dropped, scoped (below) |

## The 39

All RS 2012, mostly Santa Maria zona 135. These are sections that appear to have moved between election rounds, and the source has no `nr_turno` column to say which assignment belongs to which round. I checked whether the round was recoverable some other way — no ordering signal (median row gap 124 inside the same municipality's block, interleaved), no structural tell. It isn't.

Publishing two panel IDs for one section is worse than publishing neither, so they're dropped — but **only where the defect is known to live**. Ambiguity in any other state-year errors, because that would be a new problem rather than this one. Confirmed the guard fires with a synthetic SP-2018 case.

Issue #127 tracks the real fix: `update_secc_loc_map.R` already pulls a source exposing `NR_TURNO` and its `unique()` is what discards it. When that lands, the drop and its guard come out.

## Verification

Ran against the real production inputs, not dev mode:

- 4,330,296 rows out, key unique, no NAs in the key
- Join rates unchanged: 99.9% section→location, 96.7% location→panel
- 39 dropped, exactly as diagnosed
- `Rscript tests/testthat.R` — 258 pass

## Schema change

`section_panel_mapping.csv.gz` gains a `cd_localidade_tse` column. Additive, but it touches the published contract, so flagging it plainly.

## Review

Both layers ran. They converged on the same thing: my first version replaced the hard `stop()` with an unconditional drop, which removed all protection instead of narrowing it to the case actually verified. That's what the scoped guard fixes. Second commit also switches the column projection off `.SD`/`.SDcols` (the per-group idiom, ~20% more CPU on a 4.3M-row projection) and cuts a comment that re-derived rationale already stated at the join above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)