### PR TITLE
Score geocodebr against TSE ground truth alongside the pipeline

### DIFF
--- a/R/evaluation.R
+++ b/R/evaluation.R
@@ -241,12 +241,11 @@ select_baseline_candidates <- function(model_data) {
   unique(covered, by = "local_id")[, .(local_id, match_source, error_km)]
 }
 
-# geocodebr's own coordinate for every covered station it resolved, on the same error scale
-# the other two selectors are scored on. Candidates are read from the modeling table rather
-# than recomputed, so a geocodebr hit the pipeline could not score (a coordinate with no
-# uncertainty radius) is absent here exactly as it is absent from the model's candidates.
-# `match_source` carries the precision tier the cascade landed on: for a single-source
-# selector that is what "which source produced this coordinate" means.
+# geocodebr's own coordinate for every covered station it resolved, on the error scale the
+# other selectors are scored on. The precision tier is joined from geocodebr_match rather
+# than carried in model_data: the model recipe is dist ~ ., so every model_data column
+# becomes a predictor. It lands in `match_source` -- for a single-source selector, the
+# cascade tier is the provenance label.
 select_geocodebr_candidates <- function(model_data, geocodebr_match) {
   covered <- model_data[
     type == "geocodebr" & !is.na(dist),
@@ -258,7 +257,6 @@ select_geocodebr_candidates <- function(model_data, geocodebr_match) {
     by = "local_id"
   )
   stopifnot(
-    "geocodebr returned duplicate stations" = !anyDuplicated(out$local_id),
     "geocodebr candidate lost its precision tier in the join" = nrow(out) == nrow(covered),
     "geocodebr candidate without a precision tier" = !anyNA(out$match_source)
   )
@@ -457,38 +455,27 @@ compare_to_baseline <- function(accuracy_tables, baseline_accuracy_tables) {
   cmp[]
 }
 
-# Column pairs the head-to-head table suppresses together below the cell-size floor.
-GEOCODEBR_CMP_METRIC_COLS <- c(
-  "median_km_geocodebr",
-  "median_km_model",
-  "delta_median_km",
-  "within_500m_geocodebr",
-  "within_500m_model",
-  "delta_within_500m"
-)
-
 # geocodebr's coordinates against the pipeline's selected coordinates, both measured to the
-# TSE ground truth. Reported over two universes: every covered station, and the subset where
-# the bespoke 2022 CNEFE street/neighborhood tables currently supply the winning match --
-# the subset that decides whether geocodebr's own 2022 surface can replace them.
-#
-# Each cell scores both selectors on the stations where BOTH produced a coordinate, so a
-# metric gap is never a coverage difference in disguise; each side's coverage over the whole
-# cell rides along, because parity on the intersection means nothing if geocodebr resolves
-# far fewer stations. Deltas are geocodebr minus model, so geocodebr's advantage reads as a
-# negative median delta and a positive within-500 m delta.
+# TSE ground truth, over every covered station and over the subset the bespoke 2022 CNEFE
+# street/neighborhood tables currently win. Each cell scores both selectors on the stations
+# where both produced a coordinate, with each side's coverage of the whole cell alongside.
+# Deltas are geocodebr minus model.
 compare_geocodebr_to_model <- function(geocodebr_selected_matches, oof_selected_matches) {
-  # The reference tables under review. CNEFE-2022 schools are matched on establishment name
-  # against a different table and are not part of the proposed substitution.
-  substituted_sources <- c("st_cnefe_2022", "bairro_cnefe_2022")
+  metric_cols <- c(
+    "median_km_geocodebr",
+    "median_km_model",
+    "delta_median_km",
+    "within_500m_geocodebr",
+    "within_500m_model",
+    "delta_within_500m"
+  )
 
   paired <- merge(
     geocodebr_selected_matches[, .(
       local_id,
       urban_rural,
       region,
-      # A station geocodebr never resolved has no tier; naming the absence gives it its own
-      # level instead of dropping it out of the tier cut.
+      # Stations geocodebr never resolved get a named tier, so they form a level of their own.
       geocodebr_tier = fifelse(is.na(match_source), "sem_resultado", match_source),
       geocoded_geocodebr = geocoded,
       error_km_geocodebr = error_km
@@ -507,14 +494,14 @@ compare_geocodebr_to_model <- function(geocodebr_selected_matches, oof_selected_
   )
 
   cell <- function(dt) {
-    both <- dt[geocoded_geocodebr & geocoded_model]
-    g <- accuracy_metrics(both$error_km_geocodebr)
-    m <- accuracy_metrics(both$error_km_model)
+    both <- dt$geocoded_geocodebr & dt$geocoded_model
+    g <- accuracy_metrics(dt$error_km_geocodebr[both])
+    m <- accuracy_metrics(dt$error_km_model[both])
     list(
       n_stations = nrow(dt),
       n_geocodebr = sum(dt$geocoded_geocodebr),
       n_model = sum(dt$geocoded_model),
-      n_both = nrow(both),
+      n_both = sum(both),
       median_km_geocodebr = g$median_km,
       median_km_model = m$median_km,
       delta_median_km = g$median_km - m$median_km,
@@ -526,9 +513,10 @@ compare_geocodebr_to_model <- function(geocodebr_selected_matches, oof_selected_
 
   universes <- list(
     all_covered = paired,
-    # Every station here geocoded under the model by construction, so n_both is geocodebr's
-    # coverage of the tables it would replace.
-    cnefe22_winner = paired[model_source %in% substituted_sources]
+    # CNEFE-2022 schools are matched on establishment name against a different table, so they
+    # are not part of the proposed substitution. Every station here geocoded under the model,
+    # so n_both is geocodebr's coverage of the tables it would replace.
+    cnefe22_winner = paired[model_source %in% c("st_cnefe_2022", "bairro_cnefe_2022")]
   )
   strata <- list(
     character(0),
@@ -540,14 +528,12 @@ compare_geocodebr_to_model <- function(geocodebr_selected_matches, oof_selected_
 
   out <- rbindlist(
     lapply(names(universes), function(u) {
-      tabs <- rbindlist(
+      rbindlist(
         lapply(strata, function(s) {
-          .by_stratum(universes[[u]], s, cell, GEOCODEBR_CMP_METRIC_COLS, "n_both")
+          .by_stratum(universes[[u]], s, cell, metric_cols = metric_cols, n_col = "n_both")
         }),
         use.names = TRUE
-      )
-      tabs[, universe := u]
-      tabs[]
+      )[, universe := u]
     }),
     use.names = TRUE
   )

--- a/R/evaluation.R
+++ b/R/evaluation.R
@@ -241,6 +241,30 @@ select_baseline_candidates <- function(model_data) {
   unique(covered, by = "local_id")[, .(local_id, match_source, error_km)]
 }
 
+# geocodebr's own coordinate for every covered station it resolved, on the same error scale
+# the other two selectors are scored on. Candidates are read from the modeling table rather
+# than recomputed, so a geocodebr hit the pipeline could not score (a coordinate with no
+# uncertainty radius) is absent here exactly as it is absent from the model's candidates.
+# `match_source` carries the precision tier the cascade landed on: for a single-source
+# selector that is what "which source produced this coordinate" means.
+select_geocodebr_candidates <- function(model_data, geocodebr_match) {
+  covered <- model_data[
+    type == "geocodebr" & !is.na(dist),
+    .(local_id, error_km = dist)
+  ]
+  out <- merge(
+    covered,
+    geocodebr_match[, .(local_id, match_source = precisao_geocodebr)],
+    by = "local_id"
+  )
+  stopifnot(
+    "geocodebr returned duplicate stations" = !anyDuplicated(out$local_id),
+    "geocodebr candidate lost its precision tier in the join" = nrow(out) == nrow(covered),
+    "geocodebr candidate without a precision tier" = !anyNA(out$match_source)
+  )
+  out[]
+}
+
 # Coverage of field-collected TSE coordinates by election year x state, the ground-truth
 # density each accuracy stratum is read against. Small cells are flagged, not dropped.
 compute_tse_coverage <- function(locais, tsegeocoded_locais) {
@@ -309,37 +333,49 @@ accuracy_metrics <- function(error_km) {
   )
 }
 
-# Metric ladder plus match rate for one grouping of the covered universe. `by_cols` is
-# empty for the overall row. Accuracy is measured on geocoded stations; match rate is the
-# share of covered stations geocoded at all, always reported alongside accuracy.
-.accuracy_by <- function(dt, by_cols) {
+# Scaffolding shared by the stratified tables below: run `cell_fn` over each level of
+# `by_cols` (empty for the overall row) and stack the cells long, keyed by (stratum,
+# level). `metric_cols` are blanked wherever `n_col` falls below the cell-size floor, so
+# counts stay visible where the percentile ladder is too noisy to report.
+.by_stratum <- function(dt, by_cols, cell_fn, metric_cols, n_col) {
   stratum <- if (length(by_cols) == 0L) "overall" else paste(by_cols, collapse = ":")
   # Copy only for the overall case, which adds a synthetic grouping column.
   if (length(by_cols) == 0L) {
     dt <- copy(dt)[, .all := "all"]
     by_cols <- ".all"
   }
-  res <- dt[,
-    {
-      ng <- sum(geocoded)
-      c(
-        list(
-          n_total = .N,
-          n_geocoded = ng,
-          match_rate = 100 * ng / .N
-        ),
-        accuracy_metrics(error_km[geocoded])
-      )
-    },
-    by = by_cols
-  ]
+  res <- dt[, cell_fn(.SD), by = by_cols]
 
   res[, level := do.call(paste, c(.SD, sep = ":")), .SDcols = by_cols]
   res[, stratum := stratum]
-  # Suppress noisy metrics below the cell-size floor; counts and match rate stay visible.
-  res[n_geocoded < EVAL_MIN_CELL_N, (EVAL_METRIC_COLS) := NA_real_]
-  res[, suppressed := n_geocoded < EVAL_MIN_CELL_N]
+  res[get(n_col) < EVAL_MIN_CELL_N, (metric_cols) := NA_real_]
+  res[, suppressed := get(n_col) < EVAL_MIN_CELL_N]
   res[, (by_cols) := NULL]
+  setcolorder(res, c("stratum", "level"))
+  res[]
+}
+
+# Metric ladder plus match rate for one grouping of the covered universe. Accuracy is
+# measured on geocoded stations; match rate is the share of covered stations geocoded at
+# all, always reported alongside accuracy.
+.accuracy_by <- function(dt, by_cols) {
+  res <- .by_stratum(
+    dt,
+    by_cols,
+    function(cell) {
+      ng <- sum(cell$geocoded)
+      c(
+        list(
+          n_total = nrow(cell),
+          n_geocoded = ng,
+          match_rate = 100 * ng / nrow(cell)
+        ),
+        accuracy_metrics(cell$error_km[cell$geocoded])
+      )
+    },
+    metric_cols = EVAL_METRIC_COLS,
+    n_col = "n_geocoded"
+  )
   setcolorder(res, c("stratum", "level", "n_total", "n_geocoded", "match_rate"))
   res[]
 }
@@ -419,6 +455,107 @@ compare_to_baseline <- function(accuracy_tables, baseline_accuracy_tables) {
   )
   setorder(cmp, stratum, level)
   cmp[]
+}
+
+# Column pairs the head-to-head table suppresses together below the cell-size floor.
+GEOCODEBR_CMP_METRIC_COLS <- c(
+  "median_km_geocodebr",
+  "median_km_model",
+  "delta_median_km",
+  "within_500m_geocodebr",
+  "within_500m_model",
+  "delta_within_500m"
+)
+
+# geocodebr's coordinates against the pipeline's selected coordinates, both measured to the
+# TSE ground truth. Reported over two universes: every covered station, and the subset where
+# the bespoke 2022 CNEFE street/neighborhood tables currently supply the winning match --
+# the subset that decides whether geocodebr's own 2022 surface can replace them.
+#
+# Each cell scores both selectors on the stations where BOTH produced a coordinate, so a
+# metric gap is never a coverage difference in disguise; each side's coverage over the whole
+# cell rides along, because parity on the intersection means nothing if geocodebr resolves
+# far fewer stations. Deltas are geocodebr minus model, so geocodebr's advantage reads as a
+# negative median delta and a positive within-500 m delta.
+compare_geocodebr_to_model <- function(geocodebr_selected_matches, oof_selected_matches) {
+  # The reference tables under review. CNEFE-2022 schools are matched on establishment name
+  # against a different table and are not part of the proposed substitution.
+  substituted_sources <- c("st_cnefe_2022", "bairro_cnefe_2022")
+
+  paired <- merge(
+    geocodebr_selected_matches[, .(
+      local_id,
+      urban_rural,
+      region,
+      # A station geocodebr never resolved has no tier; naming the absence gives it its own
+      # level instead of dropping it out of the tier cut.
+      geocodebr_tier = fifelse(is.na(match_source), "sem_resultado", match_source),
+      geocoded_geocodebr = geocoded,
+      error_km_geocodebr = error_km
+    )],
+    oof_selected_matches[, .(
+      local_id,
+      model_source = match_source,
+      geocoded_model = geocoded,
+      error_km_model = error_km
+    )],
+    by = "local_id"
+  )
+  stopifnot(
+    "selectors were scored on different station universes" = nrow(paired) == nrow(geocodebr_selected_matches) &&
+      nrow(paired) == nrow(oof_selected_matches)
+  )
+
+  cell <- function(dt) {
+    both <- dt[geocoded_geocodebr & geocoded_model]
+    g <- accuracy_metrics(both$error_km_geocodebr)
+    m <- accuracy_metrics(both$error_km_model)
+    list(
+      n_stations = nrow(dt),
+      n_geocodebr = sum(dt$geocoded_geocodebr),
+      n_model = sum(dt$geocoded_model),
+      n_both = nrow(both),
+      median_km_geocodebr = g$median_km,
+      median_km_model = m$median_km,
+      delta_median_km = g$median_km - m$median_km,
+      within_500m_geocodebr = g$within_500m,
+      within_500m_model = m$within_500m,
+      delta_within_500m = g$within_500m - m$within_500m
+    )
+  }
+
+  universes <- list(
+    all_covered = paired,
+    # Every station here geocoded under the model by construction, so n_both is geocodebr's
+    # coverage of the tables it would replace.
+    cnefe22_winner = paired[model_source %in% substituted_sources]
+  )
+  strata <- list(
+    character(0),
+    "urban_rural",
+    "region",
+    c("urban_rural", "region"),
+    "geocodebr_tier"
+  )
+
+  out <- rbindlist(
+    lapply(names(universes), function(u) {
+      tabs <- rbindlist(
+        lapply(strata, function(s) {
+          .by_stratum(universes[[u]], s, cell, GEOCODEBR_CMP_METRIC_COLS, "n_both")
+        }),
+        use.names = TRUE
+      )
+      tabs[, universe := u]
+      tabs[]
+    }),
+    use.names = TRUE
+  )
+  setcolorder(
+    out,
+    c("universe", "stratum", "level", "n_stations", "n_geocodebr", "n_model", "n_both")
+  )
+  out[]
 }
 
 # Check the predicted-distance ranking the pipeline trusts for match selection, two ways:

--- a/_targets.R
+++ b/_targets.R
@@ -906,6 +906,20 @@ list(
     )
   ),
 
+  ## The same, for geocodebr's own coordinates: a third selector scored on the same
+  ## universe, whose match source is the precision tier its cascade landed on.
+  tar_target(
+    name = geocodebr_selected_matches,
+    command = attach_eval_universe(
+      select_geocodebr_candidates(model_data, geocodebr_match),
+      eval_station_universe
+    ),
+    format = "qs",
+    resources = tar_resources(
+      crew = tar_resources_crew(controller = "memory_limited")
+    )
+  ),
+
   ## Stratified accuracy tables, joint with match rate, small-cell suppressed.
   tar_target(
     name = accuracy_tables,
@@ -915,11 +929,22 @@ list(
     name = baseline_accuracy_tables,
     command = compute_accuracy_tables(baseline_selected_matches)
   ),
+  tar_target(
+    name = geocodebr_accuracy_tables,
+    command = compute_accuracy_tables(geocodebr_selected_matches)
+  ),
 
   ## Model minus baseline on the headline metrics - "is the model worth it".
   tar_target(
     name = baseline_comparison,
     command = compare_to_baseline(accuracy_tables, baseline_accuracy_tables)
+  ),
+
+  ## geocodebr minus model, paired station by station - the ground-truth comparison that
+  ## gates retiring the bespoke 2022 CNEFE street/neighborhood reference tables.
+  tar_target(
+    name = geocodebr_vs_model,
+    command = compare_geocodebr_to_model(geocodebr_selected_matches, oof_selected_matches)
   ),
 
   ## pred_dist calibration: rank-and-filter plus reliability/ENCE.

--- a/doc/geocoding_procedure.qmd
+++ b/doc/geocoding_procedure.qmd
@@ -294,10 +294,12 @@ so these figures may be marginally optimistic.)
 #| label: load-eval-targets
 # Read the pipeline-produced evaluation targets (store fallback for manual runs).
 tryCatch({
-  tar_load(c(accuracy_tables, calibration_check, tse_coverage, baseline_comparison))
+  tar_load(c(accuracy_tables, calibration_check, tse_coverage, baseline_comparison,
+             geocodebr_vs_model))
 }, error = function(e) {
   project_root <- normalizePath(file.path(getwd(), ".."), mustWork = FALSE)
-  tar_load(c(accuracy_tables, calibration_check, tse_coverage, baseline_comparison),
+  tar_load(c(accuracy_tables, calibration_check, tse_coverage, baseline_comparison,
+             geocodebr_vs_model),
            store = file.path(project_root, "_targets"))
 })
 acc <- as.data.table(accuracy_tables)
@@ -392,6 +394,46 @@ cat(sprintf(
 
 The full per-stratum comparison is in the evaluation report
 (`reports/evaluation_report.qmd`).
+
+### How much of this could an off-the-shelf geocoder do?
+
+`geocodebr` is one of the candidate sources, and it is built on IBGE's own
+aggregation of the same 2022 census address file that two of our reference tables
+--- matched street segments and matched neighborhoods --- are built from. That
+overlap raises a fair question: are those hand-built tables earning their place,
+or would the off-the-shelf geocoder do as well on its own? We answer it by
+scoring `geocodebr`'s coordinates against the TSE ground truth on the stations
+where one of those two tables currently supplies the winning match, comparing
+only stations both approaches resolve so a difference in accuracy is not a
+difference in coverage in disguise.
+
+```{r}
+#| label: geocodebr-gate-summary
+#| output: asis
+gate <- as.data.table(geocodebr_vs_model)[
+  universe == "cnefe22_winner" & stratum == "overall"
+]
+cat(sprintf(
+  paste0(
+    "On the %s covered stations the 2022 street and neighborhood tables win, ",
+    "`geocodebr` returns a coordinate for %s. Where both resolve the station, ",
+    "`geocodebr`'s median error is **%.2f km** against **%.2f km** for the ",
+    "pipeline's pick, and **%.1f%%** of its coordinates land within 500 m ",
+    "against **%.1f%%** --- a difference of **%+.2f km** and **%+.1f ",
+    "percentage points** (a negative and a positive, respectively, favour ",
+    "`geocodebr`)."
+  ),
+  format(gate$n_stations, big.mark = ","),
+  format(gate$n_geocodebr, big.mark = ","),
+  gate$median_km_geocodebr, gate$median_km_model,
+  gate$within_500m_geocodebr, gate$within_500m_model,
+  gate$delta_median_km, gate$delta_within_500m
+))
+```
+
+The breakdown by `geocodebr`'s own precision tier --- how far down its cascade
+each result came from --- is in the evaluation report, along with the same
+comparison over the whole covered set.
 
 A separate, covered-only Google reference-validation (Google-vs-TSE agreement) is
 reported in the exploratory evaluation report (`reports/evaluation_report.qmd`)

--- a/docs/specs/2026-07-evaluation-spec.md
+++ b/docs/specs/2026-07-evaluation-spec.md
@@ -252,6 +252,58 @@ side instead.
 
 ---
 
+## 7b. geocodebr vs the pipeline against TSE ground truth (added by [#41](https://github.com/fdhidalgo/geocode_br_polling_stations/issues/41))
+
+`geocodebr` is one candidate source among several, and how good its coordinates actually
+are has never been measured — the [tooling survey](../research/2026-07-geocodebr-tooling-survey.md)
+(§1.7, §4c) found no published benchmark and no in-repo comparison. This section adds one:
+wave 1d of the methodology roadmap. Measurement only; no production behavior changes.
+
+**What it answers.** geocodebr distributes its own aggregation of the 2022 CNEFE, which is
+the same source the project's bespoke 2022 street and neighborhood reference tables are
+built from. If geocodebr's surface is at parity on the stations those tables currently win,
+the tables can be retired (roadmap wave 3). If it is not, they stay. Nothing else is on the
+table: the 2010/2017 multi-vintage references, INEP matching, the arbitrator, panel linkage,
+and station-specific normalization are outside geocodebr's scope regardless.
+
+**The third selector.** `select_geocodebr_candidates()` takes geocodebr's own coordinate for
+every covered station it resolved, read out of the modeling table rather than recomputed, so
+a geocodebr hit the pipeline could not score (a coordinate with no `desvio_metros`) is absent
+here exactly as it is absent from the model's candidates. Its `match_source` is the precision
+tier the cascade landed on (`numero` / `numero_aproximado` / `logradouro` / `cep` /
+`localidade` / `municipio`) — for a single-source selector that is what "which source produced
+this coordinate" means, so the standard §4b source cut becomes the precision-tier ladder for
+free. It joins the same covered universe as the other two selectors and gets the same §4a
+metric ladder.
+
+**The head-to-head.** Unlike the §7a baseline, geocodebr and the model do *not* geocode the
+same stations: geocodebr resolves some the pipeline cannot and misses others it can. So
+`compare_geocodebr_to_model()` computes each cell's metrics on the stations where **both**
+produced a coordinate — a median gap is then a real accuracy difference, not a coverage
+difference wearing one — and reports each side's coverage over the whole cell alongside,
+because parity on the intersection means nothing if geocodebr resolves far fewer stations.
+Stations geocodebr never resolved form their own tier level (`sem_resultado`) rather than
+dropping out of the cut.
+
+**Two universes, five cuts.** Every cell is reported over *all covered stations* and over the
+`cnefe22_winner` subset — the stations whose out-of-fold winning match is `st_cnefe_2022` or
+`bairro_cnefe_2022`. (CNEFE-2022 *schools* are matched on establishment name against a
+different table and are not part of the proposed substitution.) Each universe is cut overall,
+by urban/rural, by region, by urban/rural × region, and by geocodebr precision tier. Deltas
+are **geocodebr minus model**, the opposite orientation from §7a: here the pipeline is the
+incumbent and geocodebr is the challenger, so geocodebr's advantage reads as a negative
+median delta and a positive within-500 m delta.
+
+**Reading the gate.** Parity-or-better on the `cnefe22_winner` universe, at comparable
+coverage, is what retires the tables. Read coverage through the tier cut, not the match
+rate: the cascade bottoms out at the municipal centroid, so geocodebr returns *something*
+for nearly every station and its match rate is ~100% by construction — a municipal centroid
+is a coordinate, not a located station. If geocodebr only reaches parity at
+`numero`/`logradouro` precision, the substitution is partial at best, since the bespoke
+tables are what currently carry the stations that fall to coarser rungs.
+
+---
+
 ## 8. The Google reference-validation (covered-only this round)
 
 Purpose: quantify **Google's own error budget** relative to field-GPS TSE *before*
@@ -276,7 +328,8 @@ using it as one).
 ## 9. Siting, lockstep, and gating
 
 - **Pipeline targets:** coverage (§6), OOF predictions (§3), accuracy tables (§4),
-  calibration check (§7), heuristic baseline and its comparison table (§7a) live in
+  calibration check (§7), heuristic baseline and its comparison table (§7a), geocodebr's
+  selector and its head-to-head table (§7b) live in
   `_targets.R`, rebuilt every run. Follow the readability
   rule — helper functions in `R/`, not long inline blocks. Assign memory-heavy targets to
   the `memory_limited` crew controller as needed.

--- a/docs/specs/2026-07-evaluation-spec.md
+++ b/docs/specs/2026-07-evaluation-spec.md
@@ -289,10 +289,13 @@ dropping out of the cut.
 `cnefe22_winner` subset — the stations whose out-of-fold winning match is `st_cnefe_2022` or
 `bairro_cnefe_2022`. (CNEFE-2022 *schools* are matched on establishment name against a
 different table and are not part of the proposed substitution.) Each universe is cut overall,
-by urban/rural, by region, by urban/rural × region, and by geocodebr precision tier. Deltas
-are **geocodebr minus model**, the opposite orientation from §7a: here the pipeline is the
-incumbent and geocodebr is the challenger, so geocodebr's advantage reads as a negative
-median delta and a positive within-500 m delta.
+by urban/rural, by region, by urban/rural × region, and by geocodebr precision tier.
+
+**Delta orientation, the rule for both comparison tables.** A delta is always *the subject of
+the section's question* minus *what it is compared against*, so a negative median delta and a
+positive within-500 m delta always favour the subject. §7a asks whether the model earns its
+keep, so its delta is model minus heuristic; §7b asks whether geocodebr could replace the
+tables, so its delta is geocodebr minus model.
 
 **Reading the gate.** Parity-or-better on the `cnefe22_winner` universe, at comparable
 coverage, is what retires the tables. Read coverage through the tier cut, not the match

--- a/reports/evaluation_report.qmd
+++ b/reports/evaluation_report.qmd
@@ -34,12 +34,16 @@ tar_load(c(
   accuracy_tables,
   baseline_accuracy_tables,
   baseline_comparison,
+  geocodebr_accuracy_tables,
+  geocodebr_vs_model,
   calibration_check
 ))
 
 acc <- as.data.table(accuracy_tables)
 cov <- as.data.table(tse_coverage)
 cmp <- as.data.table(baseline_comparison)
+gb_acc <- as.data.table(geocodebr_accuracy_tables)
+gb_cmp <- as.data.table(geocodebr_vs_model)
 ```
 
 ## What this report measures {.unnumbered}
@@ -194,6 +198,153 @@ src |>
   tab_header(
     title = "Which source each selector picks",
     subtitle = "Stations assigned to each candidate type. Same stations, different picks."
+  )
+```
+
+## Could `geocodebr` replace the bespoke 2022 CNEFE tables?
+
+`geocodebr` distributes IBGE's own aggregation of the 2022 CNEFE — the same source the
+project's hand-built 2022 street and neighborhood reference tables are made from. If its
+coordinates are as close to TSE ground truth as those tables' are, the tables can be
+retired. This section runs that comparison. Nothing else is at stake: the 2010/2017
+multi-vintage references, INEP school matching, the selection model, panel linkage and
+station-specific normalization are all outside `geocodebr`'s scope regardless.
+
+Unlike the heuristic above, `geocodebr` and the pipeline do **not** geocode the same
+stations — each resolves some the other cannot. So every cell below is measured on the
+stations where **both** produced a coordinate (`N both`), with each side's coverage of the
+full cell shown alongside: parity on the intersection is worth nothing if `geocodebr`
+resolves far fewer stations. **Δ is `geocodebr` minus the model** — the reverse of the
+heuristic table above, since here the pipeline is the incumbent — so a negative median Δ
+and a positive `<500 m` Δ favour **`geocodebr`**.
+
+One caveat on reading `N geocodebr`: the cascade bottoms out at the municipal centroid, so
+`geocodebr` returns *something* for nearly every station it is handed and its match rate is
+close to 100% by construction. That is not a coverage win — a municipal centroid is a
+coordinate, not a located station. The precision-tier table below is where the real coverage
+question lives.
+
+```{r}
+#| label: geocodebr-headline
+#| output: asis
+gate <- gb_cmp[universe == "cnefe22_winner" & stratum == "overall"]
+cat(sprintf(
+  paste0(
+    "**On the stations the 2022 CNEFE street/neighborhood tables currently win** ",
+    "(%s stations, of which geocodebr resolves %s): median error **%.3f km** ",
+    "(geocodebr) vs **%.3f km** (pipeline), a difference of **%+.3f km**. ",
+    "Within 500 m: **%.1f%%** vs **%.1f%%**, a difference of **%+.1f pp**."
+  ),
+  format(gate$n_stations, big.mark = ","), format(gate$n_geocodebr, big.mark = ","),
+  gate$median_km_geocodebr, gate$median_km_model, gate$delta_median_km,
+  gate$within_500m_geocodebr, gate$within_500m_model, gate$delta_within_500m
+))
+```
+
+```{r}
+#| label: geocodebr-headtohead
+gb_cmp[stratum != "geocodebr_tier"] |>
+  gt(groupname_col = "universe", rowname_col = "level") |>
+  fmt_number(
+    columns = c("median_km_geocodebr", "median_km_model", "delta_median_km"),
+    decimals = 3
+  ) |>
+  fmt_number(
+    columns = c("within_500m_geocodebr", "within_500m_model", "delta_within_500m"),
+    decimals = 1
+  ) |>
+  fmt_integer(columns = c("n_stations", "n_geocodebr", "n_model", "n_both")) |>
+  sub_missing(missing_text = "—") |>
+  cols_label(
+    stratum = "Cut", n_stations = "N", n_geocodebr = "N geocodebr", n_model = "N model",
+    n_both = "N both",
+    median_km_geocodebr = "geocodebr", median_km_model = "Pipeline",
+    delta_median_km = "Δ",
+    within_500m_geocodebr = "geocodebr", within_500m_model = "Pipeline",
+    delta_within_500m = "Δ", suppressed = "Below N floor"
+  ) |>
+  tab_spanner(
+    label = "Median error (km)",
+    columns = c("median_km_geocodebr", "median_km_model", "delta_median_km")
+  ) |>
+  tab_spanner(
+    label = "Within 500 m (%)",
+    columns = c("within_500m_geocodebr", "within_500m_model", "delta_within_500m")
+  ) |>
+  tab_header(
+    title = "geocodebr vs the pipeline's selected coordinate",
+    subtitle = paste(
+      "all_covered = every TSE-covered station;",
+      "cnefe22_winner = those the 2022 CNEFE street/neighborhood tables currently win."
+    )
+  ) |>
+  tab_source_note(
+    "Δ is geocodebr minus pipeline: negative median and positive <500 m favour geocodebr."
+  )
+```
+
+### By `geocodebr` precision tier
+
+`geocodebr` labels each result with the rung of its cascade it reached, from an exact house
+number down to the municipal centroid. The tier decides how much of the substitution is
+actually available: if `geocodebr` only reaches parity at street level or better, it cannot
+replace the tables on the stations that fall to coarser rungs — which is precisely where the
+bespoke aggregates are doing work. `sem_resultado` is the stations `geocodebr` returned
+nothing for.
+
+```{r}
+#| label: geocodebr-tier
+gb_cmp[stratum == "geocodebr_tier", .(
+  universe, Tier = level, n_stations, n_both,
+  median_km_geocodebr, median_km_model, delta_median_km,
+  within_500m_geocodebr, within_500m_model, delta_within_500m
+)] |>
+  gt(groupname_col = "universe", rowname_col = "Tier") |>
+  fmt_number(
+    columns = c("median_km_geocodebr", "median_km_model", "delta_median_km"),
+    decimals = 3
+  ) |>
+  fmt_number(
+    columns = c("within_500m_geocodebr", "within_500m_model", "delta_within_500m"),
+    decimals = 1
+  ) |>
+  fmt_integer(columns = c("n_stations", "n_both")) |>
+  sub_missing(missing_text = "—") |>
+  cols_label(
+    n_stations = "N", n_both = "N both",
+    median_km_geocodebr = "geocodebr", median_km_model = "Pipeline",
+    delta_median_km = "Δ",
+    within_500m_geocodebr = "geocodebr", within_500m_model = "Pipeline",
+    delta_within_500m = "Δ"
+  ) |>
+  tab_spanner(
+    label = "Median error (km)",
+    columns = c("median_km_geocodebr", "median_km_model", "delta_median_km")
+  ) |>
+  tab_spanner(
+    label = "Within 500 m (%)",
+    columns = c("within_500m_geocodebr", "within_500m_model", "delta_within_500m")
+  ) |>
+  tab_header(title = "Head-to-head by geocodebr precision tier")
+```
+
+```{r}
+#| label: geocodebr-standalone
+gb_acc[stratum %in% c("overall", "urban_rural", "region", "match_source")] |>
+  gt(groupname_col = "stratum", rowname_col = "level") |>
+  fmt_number(columns = c("median_km", "p90", "p95", "p99"), decimals = 3) |>
+  fmt_number(columns = c("match_rate", "within_100m", "within_500m", "within_1km"),
+             decimals = 1) |>
+  fmt_integer(columns = c("n_total", "n_geocoded")) |>
+  sub_missing(missing_text = "—") |>
+  cols_label(
+    n_total = "N covered", n_geocoded = "N geocoded", match_rate = "Match %",
+    median_km = "Median km", within_100m = "<100m %", within_500m = "<500m %",
+    within_1km = "<1km %"
+  ) |>
+  tab_header(
+    title = "geocodebr on its own, over the whole covered set",
+    subtitle = "Same metric ladder as the pipeline table above. `match_source` is the precision tier."
   )
 ```
 

--- a/reports/evaluation_report.qmd
+++ b/reports/evaluation_report.qmd
@@ -44,6 +44,54 @@ cov <- as.data.table(tse_coverage)
 cmp <- as.data.table(baseline_comparison)
 gb_acc <- as.data.table(geocodebr_accuracy_tables)
 gb_cmp <- as.data.table(geocodebr_vs_model)
+
+# One formatter per table schema, so every rendering of a schema agrees on decimals,
+# labels and spanners. Each caller adds only its own filter, counts and notes.
+acc_ladder_gt <- function(dt, title, subtitle) {
+  dt |>
+    gt(groupname_col = "stratum", rowname_col = "level") |>
+    fmt_number(columns = c("median_km", "p90", "p95", "p99"), decimals = 3) |>
+    fmt_number(columns = c("match_rate", "within_100m", "within_500m", "within_1km"),
+               decimals = 1) |>
+    fmt_integer(columns = c("n_total", "n_geocoded")) |>
+    sub_missing(missing_text = "—") |>
+    cols_label(
+      n_total = "N covered", n_geocoded = "N geocoded", match_rate = "Match %",
+      median_km = "Median km", within_100m = "<100m %", within_500m = "<500m %",
+      within_1km = "<1km %"
+    ) |>
+    tab_header(title = title, subtitle = subtitle)
+}
+
+head_to_head_gt <- function(dt, title, subtitle = NULL) {
+  dt |>
+    gt(groupname_col = "universe", rowname_col = "level") |>
+    fmt_number(
+      columns = c("median_km_geocodebr", "median_km_model", "delta_median_km"),
+      decimals = 3
+    ) |>
+    fmt_number(
+      columns = c("within_500m_geocodebr", "within_500m_model", "delta_within_500m"),
+      decimals = 1
+    ) |>
+    fmt_integer(columns = where(is.integer)) |>
+    sub_missing(missing_text = "—") |>
+    cols_label(
+      median_km_geocodebr = "geocodebr", median_km_model = "Pipeline",
+      delta_median_km = "Δ",
+      within_500m_geocodebr = "geocodebr", within_500m_model = "Pipeline",
+      delta_within_500m = "Δ"
+    ) |>
+    tab_spanner(
+      label = "Median error (km)",
+      columns = c("median_km_geocodebr", "median_km_model", "delta_median_km")
+    ) |>
+    tab_spanner(
+      label = "Within 500 m (%)",
+      columns = c("within_500m_geocodebr", "within_500m_model", "delta_within_500m")
+    ) |>
+    tab_header(title = title, subtitle = subtitle)
+}
 ```
 
 ## What this report measures {.unnumbered}
@@ -90,22 +138,8 @@ cat(sprintf(
 
 ```{r}
 #| label: acc-table
-acc_display <- copy(acc)
-num_cols <- c("match_rate", "median_km", "p90", "p95", "p99",
-              "within_100m", "within_500m", "within_1km")
-acc_display |>
-  gt(groupname_col = "stratum", rowname_col = "level") |>
-  fmt_number(columns = c("median_km", "p90", "p95", "p99"), decimals = 3) |>
-  fmt_number(columns = c("match_rate", "within_100m", "within_500m", "within_1km"),
-             decimals = 1) |>
-  fmt_integer(columns = c("n_total", "n_geocoded")) |>
-  sub_missing(columns = num_cols, missing_text = "—") |>
-  cols_label(
-    n_total = "N covered", n_geocoded = "N geocoded", match_rate = "Match %",
-    median_km = "Median km", within_100m = "<100m %", within_500m = "<500m %",
-    within_1km = "<1km %"
-  ) |>
-  tab_header(
+acc |>
+  acc_ladder_gt(
     title = "Positional accuracy on the TSE-covered set (out-of-fold)",
     subtitle = "Suppressed strata (below held-out N floor) show counts only."
   ) |>
@@ -244,39 +278,16 @@ cat(sprintf(
 ```{r}
 #| label: geocodebr-headtohead
 gb_cmp[stratum != "geocodebr_tier"] |>
-  gt(groupname_col = "universe", rowname_col = "level") |>
-  fmt_number(
-    columns = c("median_km_geocodebr", "median_km_model", "delta_median_km"),
-    decimals = 3
-  ) |>
-  fmt_number(
-    columns = c("within_500m_geocodebr", "within_500m_model", "delta_within_500m"),
-    decimals = 1
-  ) |>
-  fmt_integer(columns = c("n_stations", "n_geocodebr", "n_model", "n_both")) |>
-  sub_missing(missing_text = "—") |>
-  cols_label(
-    stratum = "Cut", n_stations = "N", n_geocodebr = "N geocodebr", n_model = "N model",
-    n_both = "N both",
-    median_km_geocodebr = "geocodebr", median_km_model = "Pipeline",
-    delta_median_km = "Δ",
-    within_500m_geocodebr = "geocodebr", within_500m_model = "Pipeline",
-    delta_within_500m = "Δ", suppressed = "Below N floor"
-  ) |>
-  tab_spanner(
-    label = "Median error (km)",
-    columns = c("median_km_geocodebr", "median_km_model", "delta_median_km")
-  ) |>
-  tab_spanner(
-    label = "Within 500 m (%)",
-    columns = c("within_500m_geocodebr", "within_500m_model", "delta_within_500m")
-  ) |>
-  tab_header(
+  head_to_head_gt(
     title = "geocodebr vs the pipeline's selected coordinate",
     subtitle = paste(
       "all_covered = every TSE-covered station;",
       "cnefe22_winner = those the 2022 CNEFE street/neighborhood tables currently win."
     )
+  ) |>
+  cols_label(
+    stratum = "Cut", n_stations = "N", n_geocodebr = "N geocodebr", n_model = "N model",
+    n_both = "N both", suppressed = "Below N floor"
   ) |>
   tab_source_note(
     "Δ is geocodebr minus pipeline: negative median and positive <500 m favour geocodebr."
@@ -295,54 +306,19 @@ nothing for.
 ```{r}
 #| label: geocodebr-tier
 gb_cmp[stratum == "geocodebr_tier", .(
-  universe, Tier = level, n_stations, n_both,
+  universe, level, n_stations, n_both,
   median_km_geocodebr, median_km_model, delta_median_km,
   within_500m_geocodebr, within_500m_model, delta_within_500m
 )] |>
-  gt(groupname_col = "universe", rowname_col = "Tier") |>
-  fmt_number(
-    columns = c("median_km_geocodebr", "median_km_model", "delta_median_km"),
-    decimals = 3
-  ) |>
-  fmt_number(
-    columns = c("within_500m_geocodebr", "within_500m_model", "delta_within_500m"),
-    decimals = 1
-  ) |>
-  fmt_integer(columns = c("n_stations", "n_both")) |>
-  sub_missing(missing_text = "—") |>
-  cols_label(
-    n_stations = "N", n_both = "N both",
-    median_km_geocodebr = "geocodebr", median_km_model = "Pipeline",
-    delta_median_km = "Δ",
-    within_500m_geocodebr = "geocodebr", within_500m_model = "Pipeline",
-    delta_within_500m = "Δ"
-  ) |>
-  tab_spanner(
-    label = "Median error (km)",
-    columns = c("median_km_geocodebr", "median_km_model", "delta_median_km")
-  ) |>
-  tab_spanner(
-    label = "Within 500 m (%)",
-    columns = c("within_500m_geocodebr", "within_500m_model", "delta_within_500m")
-  ) |>
-  tab_header(title = "Head-to-head by geocodebr precision tier")
+  head_to_head_gt(title = "Head-to-head by geocodebr precision tier") |>
+  cols_label(n_stations = "N", n_both = "N both") |>
+  tab_stubhead(label = "Tier")
 ```
 
 ```{r}
 #| label: geocodebr-standalone
 gb_acc[stratum %in% c("overall", "urban_rural", "region", "match_source")] |>
-  gt(groupname_col = "stratum", rowname_col = "level") |>
-  fmt_number(columns = c("median_km", "p90", "p95", "p99"), decimals = 3) |>
-  fmt_number(columns = c("match_rate", "within_100m", "within_500m", "within_1km"),
-             decimals = 1) |>
-  fmt_integer(columns = c("n_total", "n_geocoded")) |>
-  sub_missing(missing_text = "—") |>
-  cols_label(
-    n_total = "N covered", n_geocoded = "N geocoded", match_rate = "Match %",
-    median_km = "Median km", within_100m = "<100m %", within_500m = "<500m %",
-    within_1km = "<1km %"
-  ) |>
-  tab_header(
+  acc_ladder_gt(
     title = "geocodebr on its own, over the whole covered set",
     subtitle = "Same metric ladder as the pipeline table above. `match_source` is the precision tier."
   )

--- a/tests/testthat/test-evaluation.R
+++ b/tests/testthat/test-evaluation.R
@@ -1,8 +1,9 @@
 ## Unit tests for the deterministic evaluation-harness helpers (R/evaluation.R).
 ## These avoid the heavy pipeline (no model fitting, no spatial joins): they check
 ## the metric ladder, region mapping, coverage counting, fold assignment, the
-## trivial-heuristic baseline selector and its comparison table, and the calibration
-## rank-and-filter logic with tiny synthetic inputs.
+## trivial-heuristic baseline selector and its comparison table, the geocodebr
+## selector and its head-to-head table, and the calibration rank-and-filter logic
+## with tiny synthetic inputs.
 
 library(testthat)
 library(data.table)
@@ -184,6 +185,80 @@ test_that("compare_to_baseline signs deltas so the model's advantage is visible"
   # the two selectors rank the same candidates, so a differing geocoded count is a bug
   wrong <- copy(baseline)[stratum == "overall", n_geocoded := 79L]
   expect_error(compare_to_baseline(model, wrong), "which stations geocoded")
+})
+
+test_that("select_geocodebr_candidates keeps covered geocodebr rows with their tier", {
+  md <- data.table(
+    local_id = c(1L, 1L, 2L, 3L),
+    type = c("geocodebr", "st_cnefe_2022", "geocodebr", "geocodebr"),
+    # station 3 has no TSE coordinate, so it is not scored at all
+    dist = c(0.3, 0.9, 1.2, NA_real_)
+  )
+  gb <- data.table(
+    local_id = 1:3,
+    precisao_geocodebr = c("numero", "localidade", "municipio")
+  )
+  sel <- select_geocodebr_candidates(md, gb)
+  expect_equal(sel$local_id, c(1L, 2L))
+  expect_equal(sel$error_km, c(0.3, 1.2)) # geocodebr's row, not the CNEFE candidate's
+  expect_equal(sel$match_source, c("numero", "localidade"))
+
+  # a scored candidate that lost its tier is a broken join, not a station to score anyway
+  expect_error(select_geocodebr_candidates(md, gb[local_id != 1L]), "lost its precision tier")
+  no_tier <- copy(gb)[local_id == 1L, precisao_geocodebr := NA_character_]
+  expect_error(select_geocodebr_candidates(md, no_tier), "without a precision tier")
+})
+
+test_that("compare_geocodebr_to_model scores both selectors on both-geocoded stations", {
+  n <- 60L
+  ids <- seq_len(2L * n)
+  # First block: the model's winning match comes from the 2022 CNEFE street table (the
+  # subset the substitution decision turns on). Second block: it comes from INEP schools.
+  model_source <- rep(c("st_cnefe_2022", "schools_inep_name"), each = n)
+  # geocodebr resolves every station but the last of each block.
+  gb_geocoded <- rep(TRUE, 2L * n)
+  gb_geocoded[c(n, 2L * n)] <- FALSE
+
+  gb <- data.table(
+    local_id = ids,
+    urban_rural = "urban",
+    region = "Norte",
+    match_source = fifelse(gb_geocoded, "numero", NA_character_),
+    error_km = fifelse(gb_geocoded, 0.2, NA_real_),
+    geocoded = gb_geocoded
+  )
+  model <- data.table(
+    local_id = ids,
+    match_source = model_source,
+    error_km = 0.8,
+    geocoded = TRUE
+  )
+
+  cmp <- compare_geocodebr_to_model(gb, model)
+
+  overall <- cmp[universe == "all_covered" & stratum == "overall"]
+  expect_equal(overall$n_stations, 120L)
+  expect_equal(overall$n_geocodebr, 118L) # coverage reported, not folded into the metric
+  expect_equal(overall$n_model, 120L)
+  expect_equal(overall$n_both, 118L)
+  # deltas are geocodebr minus model, so geocodebr's advantage is a negative median delta
+  # and a positive within-500 m delta
+  expect_equal(overall$delta_median_km, 0.2 - 0.8)
+  expect_equal(overall$delta_within_500m, 100)
+
+  # the gate subset holds only the stations the 2022 CNEFE tables currently win
+  subset_overall <- cmp[universe == "cnefe22_winner" & stratum == "overall"]
+  expect_equal(subset_overall$n_stations, 60L)
+  expect_equal(subset_overall$n_both, 59L)
+
+  # a station geocodebr never resolved gets a named tier rather than dropping out
+  tiers <- cmp[universe == "all_covered" & stratum == "geocodebr_tier"]
+  expect_setequal(tiers$level, c("numero", "sem_resultado"))
+  expect_equal(tiers[level == "sem_resultado"]$n_both, 0L)
+  expect_true(tiers[level == "sem_resultado"]$suppressed)
+
+  # the two selectors must be scored on the same universe, or the pairing is meaningless
+  expect_error(compare_geocodebr_to_model(gb[-1L], model), "different station universes")
 })
 
 test_that("compute_accuracy_tables reports match rate and suppresses small cells", {


### PR DESCRIPTION
## What this is for

`geocodebr` is one of the candidate sources the pipeline picks between, and nobody has ever
measured how good its coordinates actually are — the tooling survey found no published
benchmark and no in-repo comparison. This adds one, as a third selector on the existing
evaluation harness alongside the model's out-of-fold picks and the trivial heuristic.

The question it exists to answer is narrow. `geocodebr` distributes IBGE's own aggregation of
the 2022 CNEFE — the same source our bespoke 2022 street and neighborhood reference tables are
built from. If `geocodebr` is at parity on the stations those tables currently win, the tables
can be retired (roadmap wave 3). If it isn't, they stay. Nothing else is at stake: the
2010/2017 multi-vintage references, INEP matching, the selection model, panel linkage and
station-specific normalization are outside `geocodebr`'s scope either way.

Closes #41 (wave 1d). Measurement only — no production behavior changes.

## What it adds

**`select_geocodebr_candidates()`** reads `geocodebr`'s coordinate out of the modeling table
rather than recomputing it, so a hit the pipeline could not score is absent here exactly as it
is absent there. Its `match_source` is the precision tier the cascade landed on, which makes
the harness's standard source cut the precision ladder for free.

**`compare_geocodebr_to_model()`** is the head-to-head. Unlike the heuristic baseline,
`geocodebr` and the model do *not* geocode the same stations, so each cell is measured on the
stations where **both** produced a coordinate — a median gap is then a real accuracy
difference, not a coverage difference wearing one — with each side's coverage of the full cell
reported alongside. Every cell is reported over all covered stations and over the subset the
2022 CNEFE street/neighborhood tables win, cut overall, by urban/rural, by region, by their
cross, and by precision tier.

Deltas are **`geocodebr` minus model**, the reverse of the baseline table's orientation. That
is one rule, not two exceptions, and the spec now states it once: a delta is the subject of the
section's question minus what it's compared against, so a negative median always favours the
subject.

Three new targets (`geocodebr_selected_matches`, `geocodebr_accuracy_tables`,
`geocodebr_vs_model`), sections in the evaluation report and the methodology doc, §7b in the
evaluation spec, and unit tests.

`.accuracy_by()`'s stratification scaffolding is extracted to `.by_stratum()` and shared with
the new table, so the two can't drift apart in how they key strata or apply the cell-size
floor. Output of the existing accuracy targets is unchanged.

## One thing worth knowing before reading the numbers

`geocodebr`'s cascade bottoms out at the municipal centroid, so it returns *something* for
nearly every station and its match rate is ~100% by construction. That is not a coverage win —
a municipal centroid is a coordinate, not a located station. The dev-mode (AC/RR) run shows the
spread plainly: median error 16 m at the `numero` tier against 23.5 km at `municipio`. Read
coverage through the tier cut, not the match rate.

## Verification

- `Rscript tests/testthat.R` — 286 pass
- Dev-mode (AC/RR) build of the new targets and a full render of `evaluation_report.qmd`

The production numbers that actually operate the wave-3 gate need a full rebuild; the AC/RR
figures are a smoke test, not the answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tu93mTGCWSJ3iRZbPaTPVZ
