### PR TITLE
Geocode the Distrito Federal instead of shipping it blank

### DIFF
--- a/R/panel_creation.R
+++ b/R/panel_creation.R
@@ -189,8 +189,8 @@ combine_state_panel_ids <- function(panel_ids_list) {
 
 # Group municipalities into batches of roughly equal polling-station count, so workers
 # get balanced workloads and the largest cities are not batched with anything else.
-create_panel_municipality_batches <- function(locais_data, target_batch_size = 5000) {
-  muni_counts <- locais_data[
+create_panel_municipality_batches <- function(locais, target_batch_size = 5000) {
+  muni_counts <- locais[
     !is.na(cod_localidade_ibge),
     .(n_stations = uniqueN(local_id)),
     by = .(cod_localidade_ibge, sg_uf)
@@ -235,10 +235,10 @@ create_panel_municipality_batches <- function(locais_data, target_batch_size = 5
 }
 
 # Build panel IDs for one batch of municipalities, one municipality at a time.
-process_panel_ids_municipality_batch <- function(locais_full, municipality_batch) {
+process_panel_ids_municipality_batch <- function(locais, municipality_batch) {
   muni_codes <- municipality_batch$cod_localidade_ibge
 
-  batch_data <- locais_full[cod_localidade_ibge %in% muni_codes]
+  batch_data <- locais[cod_localidade_ibge %in% muni_codes]
 
   if (nrow(batch_data) == 0) {
     cat("No data found for municipality batch\n")

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -72,12 +72,6 @@ filter_to_run_munis <- function(data, muni_col, muni_ids, dev_mode) {
   data[keys %in% as.character(muni_ids$id_munic_7), ]
 }
 
-# Drop Brasília (DF), which holds municipal elections in different years from
-# the other states.
-apply_brasilia_filters <- function(data) {
-  data[sg_uf != "DF"]
-}
-
 # Read and clean one state's CNEFE file in memory and return only the small
 # summaries the pipeline consumes: street- and neighborhood-level coordinate
 # aggregates plus the school rows. The full cleaned address table has no other
@@ -231,20 +225,20 @@ make_stbairro_batch_groups <- function(ref_st, ref_bairro, municipality_batch_as
 # Match one batch's polling stations against the INEP school catalog. inep_data
 # is this batch's slice of the catalog; municipalities come from
 # municipality_batch_assignments, which fixes the combined row order.
-process_inep_batch <- function(municipality_batch_assignments, locais_filtered, inep_data) {
+process_inep_batch <- function(municipality_batch_assignments, locais, inep_data) {
   this_batch <- inep_data$batch_id[1]
   batch_munis <- municipality_batch_assignments[
     batch_id == this_batch
   ]$cod_localidade_ibge
 
   data.table::setkey(inep_data, id_munic_7)
-  data.table::setkey(locais_filtered, cod_localidade_ibge)
+  data.table::setkey(locais, cod_localidade_ibge)
 
   batch_results <- collect_batch_or_stop(
     batch_munis,
     function(muni_code) {
       match_inep_muni(
-        locais_muni = locais_filtered[.(muni_code), nomatch = NULL],
+        locais_muni = locais[.(muni_code), nomatch = NULL],
         inep_muni = inep_data[.(muni_code), nomatch = NULL]
       )
     },
@@ -257,20 +251,20 @@ process_inep_batch <- function(municipality_batch_assignments, locais_filtered, 
 }
 
 # Match one batch's polling stations against the CNEFE school rows.
-process_schools_cnefe_batch <- function(municipality_batch_assignments, locais_filtered, schools_cnefe) {
+process_schools_cnefe_batch <- function(municipality_batch_assignments, locais, schools_cnefe) {
   this_batch <- schools_cnefe$batch_id[1]
   batch_munis <- municipality_batch_assignments[
     batch_id == this_batch
   ]$cod_localidade_ibge
 
   data.table::setkey(schools_cnefe, id_munic_7)
-  data.table::setkey(locais_filtered, cod_localidade_ibge)
+  data.table::setkey(locais, cod_localidade_ibge)
 
   batch_results <- collect_batch_or_stop(
     batch_munis,
     function(muni_code) {
       match_schools_cnefe_muni(
-        locais_muni = locais_filtered[.(muni_code), nomatch = NULL],
+        locais_muni = locais[.(muni_code), nomatch = NULL],
         schools_cnefe_muni = schools_cnefe[.(muni_code), nomatch = NULL]
       )
     },
@@ -281,17 +275,17 @@ process_schools_cnefe_batch <- function(municipality_batch_assignments, locais_f
 }
 
 # Geocode one batch's polling stations with geocodebr.
-process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, locais_filtered) {
+process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, locais) {
   batch_munis <- municipality_batch_assignments[
     batch_id == batch_ids
   ]$cod_localidade_ibge
 
-  data.table::setkey(locais_filtered, cod_localidade_ibge)
+  data.table::setkey(locais, cod_localidade_ibge)
 
   results <- collect_batch_or_stop(
     batch_munis,
     function(muni_code) {
-      match_geocodebr_muni(locais_filtered[.(muni_code), nomatch = NULL])
+      match_geocodebr_muni(locais[.(muni_code), nomatch = NULL])
     },
     task_label = "geocodebr matching"
   )
@@ -305,7 +299,7 @@ process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, l
 # any failure message.
 process_stbairro_batch <- function(
   municipality_batch_assignments,
-  locais_filtered,
+  locais,
   stbairro,
   label
 ) {
@@ -318,7 +312,7 @@ process_stbairro_batch <- function(
   bairro <- stbairro[component == "bairro"]
   data.table::setkey(st, id_munic_7)
   data.table::setkey(bairro, id_munic_7)
-  data.table::setkey(locais_filtered, cod_localidade_ibge)
+  data.table::setkey(locais, cod_localidade_ibge)
 
   message(sprintf(
     "[Batch %d] Starting %s street/neighborhood matching for %d municipalities",
@@ -330,7 +324,7 @@ process_stbairro_batch <- function(
   batch_results <- collect_batch_or_stop(
     batch_munis,
     function(muni_code) {
-      locais_muni <- locais_filtered[.(muni_code), nomatch = NULL]
+      locais_muni <- locais[.(muni_code), nomatch = NULL]
       st_muni <- st[.(muni_code), nomatch = NULL]
       bairro_muni <- bairro[.(muni_code), nomatch = NULL]
 
@@ -363,8 +357,8 @@ process_stbairro_batch <- function(
 # Size-balanced batch assignment for the polling-station municipalities, so the
 # pipeline branches over a few hundred batches instead of thousands of
 # per-municipality tasks. Dev mode uses smaller batches (two states only).
-build_municipality_batches <- function(locais_filtered, dev_mode) {
-  muni_df <- locais_filtered[, .(size = .N), by = .(cod_localidade_ibge)]
+build_municipality_batches <- function(locais, dev_mode) {
+  muni_df <- locais[, .(size = .N), by = .(cod_localidade_ibge)]
   # Sort by size with municipality code as tiebreak, then round-robin so the
   # large municipalities spread evenly across batches.
   data.table::setorder(muni_df, -size, cod_localidade_ibge)

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -297,12 +297,7 @@ process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, l
 # stbairro is this batch's slice: the union of the street and neighborhood
 # aggregates, tagged by `component`. `label` names the vintage in the log and in
 # any failure message.
-process_stbairro_batch <- function(
-  municipality_batch_assignments,
-  locais,
-  stbairro,
-  label
-) {
+process_stbairro_batch <- function(municipality_batch_assignments, locais, stbairro, label) {
   this_batch <- stbairro$batch_id[1]
   batch_munis <- municipality_batch_assignments[
     batch_id == this_batch

--- a/R/validation.R
+++ b/R/validation.R
@@ -283,18 +283,31 @@ validate_release_gates <- function(
     add_fail("Gate 2 (schema): unexpected extra columns: %s", paste(extra_cols, collapse = ", "))
   }
 
-  # Gate 3: coordinates not all-NA in any year.
-  coord_by_year <- dt[,
+  # Gate 3: coordinates not all-NA in any year-state cell. Grouping by year alone
+  # missed a whole state shipping blank in every year, which is how the Distrito
+  # Federal went out uncoordinated: 0.4% of national rows, invisible to a
+  # coverage threshold and to a per-year check.
+  coord_by_cell <- dt[,
     .(
       n = .N,
       n_coord = sum(!is.na(final_lat) & !is.na(final_long))
     ),
+    by = .(ano, sg_uf)
+  ][order(ano, sg_uf)]
+  zero_coord_cells <- coord_by_cell[n_coord == 0L]
+  if (nrow(zero_coord_cells) > 0) {
+    add_fail(
+      "Gate 3 (coords): year-state cells with zero non-NA coordinates: %s",
+      paste(zero_coord_cells$sg_uf, zero_coord_cells$ano, sep = "-", collapse = ", ")
+    )
+  }
+
+  # Gate 5 and the returned summary want national per-year counts, rolled up from
+  # the same pass rather than re-scanning the table.
+  coord_by_year <- coord_by_cell[,
+    .(n = sum(n), n_coord = sum(n_coord)),
     by = ano
   ][order(ano)]
-  zero_coord_years <- coord_by_year[n_coord == 0L, ano]
-  if (length(zero_coord_years) > 0) {
-    add_fail("Gate 3 (coords): years with zero non-NA coordinates: %s", paste(zero_coord_years, collapse = ", "))
-  }
 
   # Gate 4: output files exist on disk.
   for (p in export_paths) {

--- a/R/validation.R
+++ b/R/validation.R
@@ -70,7 +70,7 @@ validate_final_output <- function(output_data) {
 }
 
 # Checks municipality, INEP, and polling-station row counts against expected ranges.
-validate_inputs_consolidated <- function(muni_ids, inep_codes, locais_filtered, pipeline_config) {
+validate_inputs_consolidated <- function(muni_ids, inep_codes, locais, pipeline_config) {
   # Dev mode restricts the pipeline to two states, so municipality and polling-station
   # counts shrink; inep_codes is never filtered, so its range is always national.
   checks <- list(
@@ -86,7 +86,7 @@ validate_inputs_consolidated <- function(muni_ids, inep_codes, locais_filtered, 
     ),
     locais_size = list(
       name = "polling stations",
-      count = nrow(locais_filtered),
+      count = nrow(locais),
       range = if (pipeline_config$dev_mode) c(1000L, 20000L) else c(100000L, 1000000L)
     )
   )

--- a/_targets.R
+++ b/_targets.R
@@ -393,7 +393,6 @@ list(
     storage = "worker",
     retrieval = "worker"
   ),
-  # Locais data filtered by development mode
   tar_target(
     name = locais,
     command = filter_by_dev_mode(locais_all, pipeline_config$dev_states, "sg_uf"),
@@ -435,7 +434,7 @@ list(
   tar_target(
     name = panel_municipality_batches,
     command = create_panel_municipality_batches(
-      locais_data = locais,
+      locais = locais,
       target_batch_size = ifelse(pipeline_config$dev_mode, 2000, 5000)
     )
   ),
@@ -451,7 +450,7 @@ list(
     name = panel_ids_by_batch,
     # panel_batch_ids is this branch's batch id.
     command = process_panel_ids_municipality_batch(
-      locais_full = locais,
+      locais = locais,
       municipality_batch = panel_municipality_batches[batch_id == panel_batch_ids]
     ),
     pattern = map(panel_batch_ids),

--- a/_targets.R
+++ b/_targets.R
@@ -399,19 +399,13 @@ list(
     command = filter_by_dev_mode(locais_all, pipeline_config$dev_states, "sg_uf"),
     format = "qs"
   ),
-  # Filter Brasília from municipal election years - using helper function
-  tar_target(
-    name = locais_filtered,
-    command = apply_brasilia_filters(locais),
-    format = "qs"
-  ),
   # Consolidated input validation - checks dataset sizes
   tar_target(
     name = validate_inputs,
     command = validate_inputs_consolidated(
       muni_ids = muni_ids,
       inep_codes = inep_codes,
-      locais_filtered = locais_filtered,
+      locais = locais,
       pipeline_config = pipeline_config
     )
   ),
@@ -432,7 +426,7 @@ list(
     command = clean_tsegeocoded_locais(
       tse_files = tse_files,
       muni_ids = muni_ids,
-      locais = locais_filtered
+      locais = locais
     ),
     format = "qs"
   ),
@@ -441,7 +435,7 @@ list(
   tar_target(
     name = panel_municipality_batches,
     command = create_panel_municipality_batches(
-      locais_data = locais_filtered,
+      locais_data = locais,
       target_batch_size = ifelse(pipeline_config$dev_mode, 2000, 5000)
     )
   ),
@@ -457,7 +451,7 @@ list(
     name = panel_ids_by_batch,
     # panel_batch_ids is this branch's batch id.
     command = process_panel_ids_municipality_batch(
-      locais_full = locais_filtered,
+      locais_full = locais,
       municipality_batch = panel_municipality_batches[batch_id == panel_batch_ids]
     ),
     pattern = map(panel_batch_ids),
@@ -518,7 +512,7 @@ list(
   # Size-balanced municipality batches, the unit every match target branches over.
   tar_target(
     name = municipality_batch_assignments,
-    command = build_municipality_batches(locais_filtered, pipeline_config$dev_mode)
+    command = build_municipality_batches(locais, pipeline_config$dev_mode)
   ),
 
   # Extract unique batch IDs for dynamic branching
@@ -598,7 +592,7 @@ list(
     name = inep_string_match_batch,
     command = process_inep_batch(
       municipality_batch_assignments = municipality_batch_assignments,
-      locais_filtered = locais_filtered,
+      locais = locais,
       inep_data = inep_grouped
     ),
     pattern = map(inep_grouped),
@@ -620,7 +614,7 @@ list(
     name = schools_cnefe10_match_batch,
     command = process_schools_cnefe_batch(
       municipality_batch_assignments = municipality_batch_assignments,
-      locais_filtered = locais_filtered,
+      locais = locais,
       schools_cnefe = schools_cnefe10_grouped
     ),
     pattern = map(schools_cnefe10_grouped),
@@ -643,7 +637,7 @@ list(
     name = schools_cnefe22_match_batch,
     command = process_schools_cnefe_batch(
       municipality_batch_assignments = municipality_batch_assignments,
-      locais_filtered = locais_filtered,
+      locais = locais,
       schools_cnefe = schools_cnefe22_grouped
     ),
     pattern = map(schools_cnefe22_grouped),
@@ -669,7 +663,7 @@ list(
     name = cnefe10_stbairro_match_batch,
     command = process_stbairro_batch(
       municipality_batch_assignments = municipality_batch_assignments,
-      locais_filtered = locais_filtered,
+      locais = locais,
       stbairro = cnefe10_stbairro_grouped,
       label = "CNEFE 2010"
     ),
@@ -693,7 +687,7 @@ list(
     name = cnefe22_stbairro_match_batch,
     command = process_stbairro_batch(
       municipality_batch_assignments = municipality_batch_assignments,
-      locais_filtered = locais_filtered,
+      locais = locais,
       stbairro = cnefe22_stbairro_grouped,
       label = "CNEFE 2022"
     ),
@@ -717,7 +711,7 @@ list(
     name = agrocnefe_stbairro_match_batch,
     command = process_stbairro_batch(
       municipality_batch_assignments = municipality_batch_assignments,
-      locais_filtered = locais_filtered,
+      locais = locais,
       stbairro = agrocnefe_stbairro_grouped,
       label = "Agro CNEFE"
     ),
@@ -749,7 +743,7 @@ list(
     command = process_geocodebr_batch(
       batch_ids = batch_ids,
       municipality_batch_assignments = municipality_batch_assignments,
-      locais_filtered = locais_filtered
+      locais = locais
     ),
     pattern = map(batch_ids),
     iteration = "list",
@@ -806,7 +800,7 @@ list(
       geocodebr_match = geocodebr_match,
       muni_demo = muni_demo,
       muni_area = muni_area,
-      locais = locais_filtered,
+      locais = locais,
       tsegeocoded_locais = tsegeocoded_locais
     ),
     storage = "worker",
@@ -843,14 +837,14 @@ list(
   ## TSE coverage by year x state - ground-truth density.
   tar_target(
     name = tse_coverage,
-    command = compute_tse_coverage(locais_filtered, tsegeocoded_locais)
+    command = compute_tse_coverage(locais, tsegeocoded_locais)
   ),
 
   ## Raw per-year TSE coordinate availability - the ceiling landed coverage is read
   ## against by the near-lossless join tripwire in the release gates.
   tar_target(
     name = tse_raw_availability,
-    command = compute_tse_raw_availability(tse_files, locais_filtered)
+    command = compute_tse_raw_availability(tse_files, locais)
   ),
 
   ## Station-grouped fold assignment, created once upstream of any refit so a fold
@@ -881,7 +875,7 @@ list(
   ## model and the baseline selector are both scored against.
   tar_target(
     name = eval_station_universe,
-    command = build_eval_universe(locais_filtered, tsegeocoded_locais, tract_shp),
+    command = build_eval_universe(locais, tsegeocoded_locais, tract_shp),
     format = "qs"
   ),
 

--- a/reports/polling_station_sanity_check.qmd
+++ b/reports/polling_station_sanity_check.qmd
@@ -107,51 +107,6 @@ if (length(warnings) > 0) {
 }
 ```
 
-## Data Preprocessing Notes {.callout-info}
-
-### Brasília (DF) Filtering
-
-The Federal District (Brasília) has a special electoral status:
-- **No municipal elections**: As a Federal District, Brasília does not hold mayoral or city council elections
-- **Federal/State elections only**: Participates only in presidential, gubernatorial, senatorial, and legislative elections (every 4 years)
-
-**Filtering Applied**: 
-- Brasília polling stations have been removed from municipal election years (2008, 2012, 2016, 2020, 2024)
-- This filtering ensures accurate municipality counts and prevents false anomalies in year-over-year comparisons
-
-```{r}
-#| label: brasilia-filtering-summary
-
-# Check if Brasília appears in municipal years (should be 0 after filtering)
-municipal_years <- c(2008, 2012, 2016, 2020, 2024)
-federal_years <- c(2006, 2010, 2014, 2018, 2022)
-
-df_summary <- geocoded_locais[sg_uf == "DF", .(
-  n_stations = uniqueN(local_id),
-  n_records = .N
-), by = ano][order(ano)]
-
-if (nrow(df_summary) > 0) {
-  df_summary[, election_type := ifelse(ano %in% municipal_years, "Municipal", "Federal/State")]
-  
-  # Display summary
-  kable(df_summary, 
-        caption = "Brasília (DF) presence by election year",
-        col.names = c("Year", "Polling Stations", "Records", "Election Type"),
-        align = c("c", "r", "r", "c"))
-} else {
-  cat("No Brasília data found in the dataset.")
-}
-
-# Verify filtering worked
-df_in_municipal <- geocoded_locais[sg_uf == "DF" & ano %in% municipal_years, .N]
-if (df_in_municipal > 0) {
-  cat("\n⚠️ WARNING: Found", df_in_municipal, "Brasília records in municipal election years. Filtering may not have been applied correctly.\n")
-} else {
-  cat("\n✅ Brasília filtering verified: No records found in municipal election years.\n")
-}
-```
-
 ## 1. Year-over-Year Polling Station Changes
 
 ```{r}
@@ -284,7 +239,7 @@ if (nrow(state_changes_plot) > 0) {
 ::: {.callout-note}
 **Note on Municipality Counts**: 
 - Brazil has approximately 5,570 municipalities
-- Brasília (DF) is counted as a municipality but only appears in federal/state election years
+- The Federal District is not a municipality, but carries one IBGE code (5300108) covering all of Brasília, so counts come to 5,571
 - New municipalities may be created through administrative divisions (e.g., Mojuí dos Campos in 2010)
 - The total count may vary by year due to these administrative changes
 :::

--- a/scripts/generate_google_reference.R
+++ b/scripts/generate_google_reference.R
@@ -34,9 +34,9 @@ if (!nzchar(api_key)) {
 }
 
 ## ---- Build the stratified covered sample ---------------------------------
-# oof_selected_matches carries the covered universe with strata; locais_filtered
-# and tsegeocoded_locais supply the address to send and the TSE coord to compare.
-tar_load(c(oof_selected_matches, locais_filtered, tsegeocoded_locais))
+# oof_selected_matches carries the covered universe with strata; locais and
+# tsegeocoded_locais supply the address to send and the TSE coord to compare.
+tar_load(c(oof_selected_matches, locais, tsegeocoded_locais))
 
 sel <- as.data.table(oof_selected_matches)
 covered <- sel[!is.na(urban_rural)] # need a stratum to sample within
@@ -47,7 +47,7 @@ sampled <- covered[,
   by = .(urban_rural, region)
 ]
 
-addr <- as.data.table(locais_filtered)[
+addr <- as.data.table(locais)[
   local_id %in% sampled$local_id,
   .(local_id, nr_zona, nr_locvot, cod_localidade_ibge, ds_endereco, ds_bairro, nm_localidade = nm_localidade, sg_uf)
 ]


### PR DESCRIPTION
## What this is about

Every polling station in Brasília has been shipping with no coordinates — 3,981 station-years, which is 3,981 of the 3,984 missing coordinates in the entire released file. The national capital was the single largest gap in the dataset, and it was invisible in the summary statistics because rows with no coordinate never enter a coverage or accuracy computation.

This makes the pipeline geocode Brasília like everywhere else, and widens the release check that should have caught this in the first place.

## Why it was happening

Two lines disagreed about which table was authoritative. `locais_filtered` dropped `sg_uf == "DF"` and fed every matching target; the export called `finalize_coords(locais, ...)` on the unfiltered table. So DF was excluded from the work and included in the output.

The filter was never meant to do that. It started as a year-conditional drop — DF only in municipal election years — and was flattened into an unconditional `sg_uf != "DF"` during a consolidation refactor. The comment above it still described the old behavior.

Its stated purpose had also stopped working. It existed to suppress false year-over-year anomalies in the sanity-check report, but that report reads the unfiltered table, so it was printing `⚠️ WARNING: Found 1102 Brasília records in municipal election years` — a warning about the very rows the filter was supposed to have removed.

## Why geocoding DF is the right call, not excluding it

Nothing about Brasília makes it expensive. It is one municipality with at most 618 stations in a year, against São Paulo's 2,063. Its CNEFE is 9.9 MB against São Paulo's 194 MB. Production already cleaned DF's CNEFE on every run and threw the result away, so this costs nothing that wasn't already being paid.

## What changed

- Deleted `apply_brasilia_filters()` and the `locais_filtered` target. Every consumer now reads `locais` — the same table the export uses, so the two lines can no longer disagree.
- Removed the sanity-check section documenting the filter, and corrected its municipality-count note.
- Fixed `scripts/generate_google_reference.R`, which still loaded the deleted target and would have failed outright.
- **Widened Gate 3 from per-year to per-year-and-state.** This is the part worth a look. The gate asked whether any *year* shipped with zero coordinates. DF was blank in every year, but at 0.4% of national rows it sat under the 95% coverage alarm and never produced an all-blank year, so it passed all nine gates and shipped. Grouping by year and state catches a whole unit going blank, which is the shape this bug actually had.

## Verification

Dev mode is AC/RR, so it cannot exercise DF at all. I ran a throwaway probe with DF temporarily added to the dev subset, into a separate store, then reverted the config:

- All 3,981 DF station-years geocode. Coverage goes 0% → 100%.
- Every coordinate falls inside Brasília's real bounding box (lat -16.049 to -15.506, lon -48.258 to -47.374); zero outliers.
- TSE ground truth supplies exact coordinates for 604 of 612 stations in 2018 and 612 of 618 in 2022. The 2006–2014 years come from the model.
- Panel linkage bridges DF's missing municipal years: 599 panels span 2014→2018 and 611 span 2018→2022, with 493 spanning all seven years DF appears in.

Gate 3 was checked against real data both ways — it flags exactly the seven DF year-state cells on the currently released file, and passes clean on the rebuilt output. Its per-year rollup is byte-identical to what Gate 5 was computing before.

Also: full AC/RR dev pipeline green (exit 0, release gates pass), 308 unit tests pass, `air format --check` clean.

## One thing for the release notes

This is a public dataset and the user-visible change is real: every prior release shipped DF station-years with empty `long`/`lat`. Anyone who filtered on non-missing coordinates was silently excluding Brasília. Worth a line in the next release's notes.

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbYXzBsikgPwYMaxdZAkkH