### PR TITLE
Drop the dead match_bairro_schools_cnefe column

### DIFF
--- a/R/string_matching.R
+++ b/R/string_matching.R
@@ -134,7 +134,6 @@ match_schools_cnefe_muni <- function(locais_muni, schools_cnefe_muni) {
     mindist_schools_cnefe = name_results$min_dist,
     match_long_schools_cnefe = schools_cnefe_muni$cnefe_long[idx],
     match_lat_schools_cnefe = schools_cnefe_muni$cnefe_lat[idx],
-    match_bairro_schools_cnefe = schools_cnefe_muni$norm_bairro[idx],
     sim_name_schools_cnefe = field_distance(locais_muni$normalized_name, schools_cnefe_muni$norm_desc[idx]),
     sim_street_schools_cnefe = field_distance(locais_muni$normalized_st, schools_cnefe_muni$norm_street[idx]),
     sim_bairro_schools_cnefe = field_distance(locais_muni$normalized_bairro, schools_cnefe_muni$norm_bairro[idx]),

--- a/tests/testthat/test-match_schools_cnefe_muni.R
+++ b/tests/testthat/test-match_schools_cnefe_muni.R
@@ -1,7 +1,7 @@
 ## Spec tests for match_schools_cnefe_muni() (R/string_matching.R).
 ## Matches polling-station names against CNEFE school descriptions, attaching the
-## CNEFE coordinates and neighbourhood of the best name match, plus a similarity
-## per address field. Empty CNEFE input returns NULL.
+## CNEFE coordinates of the best name match, plus a similarity per address field.
+## Empty CNEFE input returns NULL.
 
 make_locais <- function() {
   data.table::data.table(
@@ -22,7 +22,7 @@ make_schools_cnefe <- function() {
   )
 }
 
-test_that("match_schools_cnefe_muni attaches coordinates and bairro of the best name match", {
+test_that("match_schools_cnefe_muni attaches coordinates of the best name match", {
   out <- match_schools_cnefe_muni(make_locais(), make_schools_cnefe())
   expect_equal(nrow(out), 2L)
   r1 <- out[local_id == 1L]
@@ -30,7 +30,6 @@ test_that("match_schools_cnefe_muni attaches coordinates and bairro of the best 
   expect_equal(r1$mindist_schools_cnefe, 0)
   expect_equal(r1$match_long_schools_cnefe, -60)
   expect_equal(r1$match_lat_schools_cnefe, -9)
-  expect_equal(r1$match_bairro_schools_cnefe, "centro")
 })
 
 test_that("match_schools_cnefe_muni scores name, street and bairro of the selected row", {
@@ -61,7 +60,6 @@ test_that("match_schools_cnefe_muni leaves a non-matching station NA", {
   r2 <- out[local_id == 2L]
   expect_true(is.na(r2$match_schools_cnefe))
   expect_true(is.na(r2$match_long_schools_cnefe))
-  expect_true(is.na(r2$match_bairro_schools_cnefe))
   # No selected reference row means no field to compare against.
   expect_true(is.na(r2$sim_name_schools_cnefe))
   expect_true(is.na(r2$sim_street_schools_cnefe))


### PR DESCRIPTION
## What this is

`match_schools_cnefe_muni()` was returning a column that no code anywhere read. This removes it. Nothing about the geocoding changes — the column was carried through every match batch and into the combined targets purely as dead weight.

Closes #123

## The column

`match_bairro_schools_cnefe` held the normalized neighborhood of whichever CNEFE school row won the name match. Checks that it is genuinely unconsumed:

- `melt_match_candidates()` (`R/model.R:36`) lists its measure columns by name — `match_long_`, `match_lat_`, `mindist_`, `sim_*`. The bairro column was in no group. The comment there says the listing is deliberate, so that a missing column errors instead of silently shifting values onto the wrong row; dropping an unlisted column is inert.
- `string_match_coord_cols()` (`R/string_match_diagnostics.R:6`) hardcodes long/lat per target. No prefix globbing in that file.
- Repo-wide grep for the name now returns nothing.

The neighborhood signal is unaffected: `sim_bairro_schools_cnefe`, added in #39, is emitted on the adjacent line and remains a live model feature.

## Verification

- `Rscript tests/testthat.R` — 331 pass, 0 fail.
- Dev mode (AC/RR) rebuild of the invalidated targets and their first consumer: `schools_cnefe10_match`, `schools_cnefe22_match`, `model_data` all completed clean.
- Post-rebuild inspection: the column is gone from `schools_cnefe10_match`; `model_data` still carries all 11 candidate types and 34,992 non-NA `sim_bairro` values.

## Rebuild cost

This invalidates `schools_cnefe10_match` and `schools_cnefe22_match`, so a production run re-does the schools-CNEFE matching. Seconds in dev mode; the memory-heavy leg in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)