### PR TITLE
Call geocodebr once per batch instead of once per municipality

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,6 +1,18 @@
 source("renv/activate.R")
 
 options(Ncpus = parallel::detectCores())
+
+# geocodebr runs DuckDB inside a fresh subprocess per call. Without a persistent extension
+# directory each one re-downloads its DuckDB extensions into a temp dir that dies with the
+# process -- thousands of downloads over a production run. A user-level path (not the repo)
+# so every worktree shares one copy. An existing setting wins.
+if (!nzchar(Sys.getenv("DUCKDB_EXTENSION_DIRECTORY"))) {
+  local({
+    dir <- tools::R_user_dir("duckdb", "cache")
+    dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+    Sys.setenv(DUCKDB_EXTENSION_DIRECTORY = dir)
+  })
+}
 #Prefer binary packages to avoid compilation issues
 options(pkgType = "binary")
 options(renv.config.pak.enabled = TRUE)

--- a/.Rprofile
+++ b/.Rprofile
@@ -10,6 +10,11 @@ if (!nzchar(Sys.getenv("DUCKDB_EXTENSION_DIRECTORY"))) {
   local({
     dir <- tools::R_user_dir("duckdb", "cache")
     dir.create(dir, recursive = TRUE, showWarnings = FALSE)
+    # Fail here rather than let DuckDB fail later, inside a geocoding worker, pointed at a
+    # directory that does not exist.
+    if (!dir.exists(dir)) {
+      stop("could not create DuckDB extension directory: ", dir)
+    }
     Sys.setenv(DUCKDB_EXTENSION_DIRECTORY = dir)
   })
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ The project uses `targets` package for pipeline management with these stages:
 Other source files: `R/config.R` (pipeline config + crew controllers), `R/utilities.R` (helpers, `%||%`), `R/string_match_diagnostics.R` (match-quality reporting). Inventory functions with `grep "<- function" R/*.R`.
 
 ### Key Functions
-- **String Matching**: `match_inep_muni()`, `match_schools_cnefe_muni()`, `match_stbairro_cnefe_muni()`, `match_geocodebr_muni()` - fuzzy matching with Levenshtein/string distance (`R/string_matching.R`)
+- **String Matching**: `match_inep_muni()`, `match_schools_cnefe_muni()`, `match_stbairro_cnefe_muni()`, `match_geocodebr()` - fuzzy matching with Levenshtein/string distance (`R/string_matching.R`)
 - **Panel IDs**: Fellegi-Sunter record linkage (`reclin2`) with Jaro-Winkler similarity (`R/panel_creation.R`)
 - **Data Cleaning**: `normalize_address()`, `normalize_school()`, `clean_inep()`, `clean_agro_cnefe()`, `clean_tsegeocoded_locais()` (`R/data_cleaning.R`)
 - **Parallel Processing**: Uses `crew` (mirai-backed) local controllers, not `future`. Two controllers are defined in `get_crew_controllers()` in `R/config.R`: `standard` (up to 28 workers) and `memory_limited` (up to 8 workers) for memory-heavy CNEFE/matching targets. Assign a target to one via `resources = tar_resources(crew = tar_resources_crew(controller = "memory_limited"))`.

--- a/R/string_matching.R
+++ b/R/string_matching.R
@@ -198,28 +198,32 @@ record_geocodebr_provenance <- function() {
   )
 }
 
-match_geocodebr_muni <- function(locais_muni) {
-  # Match polling stations with geocodebr for a single municipality.
-
-  # Geocoding errors propagate to the caller; a municipality never drops out silently.
+# estado and municipio are ordinary columns to geocodebr, so any set of stations geocodes in
+# one call regardless of how many municipalities it spans. Cost is almost entirely the fixed
+# per-call subprocess startup (~2.1 s: callr, package load, DuckDB init, 4.5 GB CNEFE cache
+# attach) against ~0.16 ms/row, so callers should pass the largest set they have.
+match_geocodebr <- function(locais) {
+  # Geocoding errors propagate to the caller; a station never drops out silently.
   if (!requireNamespace("geocodebr", quietly = TRUE)) {
-    stop("geocodebr package not installed; it is required for match_geocodebr_muni().")
+    stop("geocodebr package not installed; it is required for match_geocodebr().")
   }
 
   # No polling stations to geocode is a legitimate empty case, not an error.
-  if (nrow(locais_muni) == 0) {
+  if (nrow(locais) == 0) {
     return(NULL)
   }
 
-  muni_code <- unique(locais_muni$cod_localidade_ibge)
-  muni_name <- unique(locais_muni$nm_localidade)
-  message(sprintf("Processing municipality: %s (%s)", muni_name[1], muni_code[1]))
+  message(sprintf(
+    "geocodebr: %d stations across %d municipalities",
+    nrow(locais),
+    uniqueN(locais$cod_localidade_ibge)
+  ))
 
   # geocodebr cascades from the most precise field combination it can satisfy down to the
   # municipality centroid, so every field supplied is a rung it can reach. local_id rides
   # along as a non-address column: geocodebr reattaches it to each result itself, rather
   # than us reassigning coordinates by position afterward.
-  dt_geocode <- locais_muni[, .(
+  dt_geocode <- locais[, .(
     local_id = local_id,
     estado = sg_uf,
     municipio = clean_text_for_geocodebr(nm_localidade),
@@ -262,7 +266,7 @@ match_geocodebr_muni <- function(locais_muni) {
     resolver_empates = TRUE,
     verboso = FALSE,
     cache = TRUE,
-    # crew already runs a worker per municipality; leave the cores to it.
+    # crew already runs a worker per batch; leave the cores to it.
     n_cores = 1
   )
 
@@ -285,8 +289,8 @@ match_geocodebr_muni <- function(locais_muni) {
   found_addr <- normalize_address(sub(",.*$", "", geocoded_result$endereco_encontrado))
   street_tiers <- c("numero", "numero_aproximado", "logradouro")
   found_addr[!geocoded_result$precisao %in% street_tiers] <- NA_character_
-  station_addr <- locais_muni$normalized_addr[
-    match(geocoded_result$local_id, locais_muni$local_id)
+  station_addr <- locais$normalized_addr[
+    match(geocoded_result$local_id, locais$local_id)
   ]
 
   # Create output in format consistent with other matching functions

--- a/R/string_matching.R
+++ b/R/string_matching.R
@@ -201,7 +201,8 @@ record_geocodebr_provenance <- function() {
 # estado and municipio are ordinary columns to geocodebr, so any set of stations geocodes in
 # one call regardless of how many municipalities it spans. Cost is almost entirely the fixed
 # per-call subprocess startup (~2.1 s: callr, package load, DuckDB init, 4.5 GB CNEFE cache
-# attach) against ~0.16 ms/row, so callers should pass the largest set they have.
+# attach) against ~0.16 ms/row, so a call should cover as many municipalities as it can.
+# In the pipeline that is one crew batch -- batch size is set by parallelism, not by this.
 match_geocodebr <- function(locais) {
   # Geocoding errors propagate to the caller; a station never drops out silently.
   if (!requireNamespace("geocodebr", quietly = TRUE)) {
@@ -275,12 +276,21 @@ match_geocodebr <- function(locais) {
     return(NULL)
   }
 
-  # Assert the round-trip so a coordinate can never be tied to the wrong station.
-  stopifnot(
-    "local_id" %in% names(geocoded_result),
-    nrow(geocoded_result) == nrow(dt_geocode),
-    !anyNA(geocoded_result$local_id)
-  )
+  # Assert the round-trip so a coordinate can never be tied to the wrong station. The call
+  # spans a whole batch, so name the municipalities: otherwise a tripped assertion says only
+  # that one of ~15 of them is bad.
+  if (
+    !("local_id" %in% names(geocoded_result)) ||
+      nrow(geocoded_result) != nrow(dt_geocode) ||
+      anyNA(geocoded_result$local_id)
+  ) {
+    stop(sprintf(
+      "geocodebr did not round-trip local_id: %d rows in, %d out, for municipalities %s",
+      nrow(dt_geocode),
+      nrow(geocoded_result),
+      paste(sort(unique(locais$cod_localidade_ibge)), collapse = ", ")
+    ))
+  }
 
   # geocodebr returns one formatted string, "STREET, NUMBER - BAIRRO, MUNICIPIO - UF",
   # rather than structured fields, so the only field feature available is a

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -284,7 +284,9 @@ process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, l
 
   data.table::setkey(locais, cod_localidade_ibge)
 
-  match_geocodebr(locais[.(batch_munis), nomatch = NULL])
+  # rbindlist so an empty batch is a zero-row table, as in the sibling batch helpers --
+  # match_geocodebr() signals empty with NULL, and this is the only branched match target.
+  rbindlist(list(match_geocodebr(locais[.(batch_munis), nomatch = NULL])))
 }
 
 # Street/neighborhood match batch, shared by the CNEFE and Agro CNEFE vintages.

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -274,7 +274,9 @@ process_schools_cnefe_batch <- function(municipality_batch_assignments, locais, 
   rbindlist(batch_results, use.names = TRUE, fill = TRUE)
 }
 
-# Geocode one batch's polling stations with geocodebr.
+# Geocode one batch's polling stations with geocodebr, in a single call. Unlike the other
+# match_*_muni functions, geocodebr needs no per-municipality reference slice, and its cost
+# is per call rather than per row -- so the batch goes to it whole.
 process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, locais) {
   batch_munis <- municipality_batch_assignments[
     batch_id == batch_ids
@@ -282,15 +284,7 @@ process_geocodebr_batch <- function(batch_ids, municipality_batch_assignments, l
 
   data.table::setkey(locais, cod_localidade_ibge)
 
-  results <- collect_batch_or_stop(
-    batch_munis,
-    function(muni_code) {
-      match_geocodebr_muni(locais[.(muni_code), nomatch = NULL])
-    },
-    task_label = "geocodebr matching"
-  )
-
-  rbindlist(results, use.names = TRUE, fill = TRUE)
+  match_geocodebr(locais[.(batch_munis), nomatch = NULL])
 }
 
 # Street/neighborhood match batch, shared by the CNEFE and Agro CNEFE vintages.


### PR DESCRIPTION
## What this is about

The pipeline geocodes polling stations partly by handing addresses to the `geocodebr` package. It was calling `geocodebr` separately for each of Brazil's ~5,600 municipalities, and each of those calls starts a whole new R process, loads packages, and opens a 4.5 GB address database before geocoding anything. That setup cost is the same whether the call geocodes 20 addresses or 1,500 — so paying it 5,600 times wastes about three CPU-hours per production run, doing nothing but starting up.

`geocodebr` accepts state and municipality as ordinary columns, so it can take many municipalities at once. This PR passes it a whole batch instead of one municipality, which is ~372 calls instead of ~5,600.

Closes #125.

## Changes

- `match_geocodebr_muni()` → `match_geocodebr()`, taking any set of stations. Nothing in the body was actually municipality-scoped except a log line.
- `process_geocodebr_batch()` passes the batch in one call, dropping the per-municipality loop.
- `.Rprofile` sets `DUCKDB_EXTENSION_DIRECTORY` to a persistent user-level path (the issue's second item) — otherwise every subprocess re-downloads its DuckDB extensions into a temp dir that dies with it.

## Measurements

25 AC municipalities, 8,404 station-years:

| shape | calls | elapsed |
|---|---|---|
| per-municipality | 25 | 52.4 s |
| batched | 1 | 3.8 s |

13.8x, or 2.02 s saved per eliminated call — consistent with the ~2.1 s startup measured in #125. Extrapolated to ~5,200 eliminated calls nationally, ~2.9 CPU-hours. **The national figure is an extrapolation, not a measurement** — verifying it needs a production run.

Verified in dev mode (AC/RR) only: full pipeline rebuilds clean through `release_gates` and `evaluation_report` (21 targets, 0 errors), 331 unit tests pass.

## Output change, and why it isn't this PR's doing

Rebuilding the AC/RR dev store changed 8 of 10,006 rows of `geocodebr_match`: the *bairro* text inside geocodebr's returned address string, plus `desvio_km_geocodebr` on one row. Coordinates did not move — zero movement across the 8,404-row benchmark.

That churn is not caused by batching. Shuffling the input row order *within a single municipality* reproduces the same differences on the same `local_id`s. The cause is in geocodebr 0.6.3's `trata_empates_geocode_duckdb()`, which picks the representative among tied candidates with `ORDER BY contagem_cnefe DESC` and no tiebreaker; ties are broken by whatever DuckDB's execution happens to yield. Filed separately as #137, which also notes that in one branch (`df_empates_perdidos`) the arbitrary winner supplies `lat`/`lon` directly, so a published coordinate could move there — not observed in AC/RR, but the SQL permits it.

Worth knowing before the next production rebuild: geocodebr features are not bit-reproducible across runs that reorder `locais`.

## Review

`/code-review medium` found no correctness bugs and confirmed the two things most likely to break: `local_id` is `.I` over the whole table, so the widened `match()` cannot cross-attach an address, and every downstream join keys on `local_id` rather than row order. Its four low findings are addressed in the second commit — batch-level error attribution, target type uniformity, and a swallowed `dir.create()` failure.

Two things it raised that are **not** fixed here:

- On a cold DuckDB extension cache (new machine, or a DuckDB version bump), up to 28 workers may install the same extension concurrently. Mitigation is operational: make one geocoding call single-threaded before the first production run after a DuckDB upgrade.
- `sim_addr_geocodebr` treats `precisao == "logradouro"` as a street tier, but at that tier the returned string has no house number, so the text before the first comma is `STREET - BAIRRO` and the similarity is computed against a contaminated string. Pre-existing, noted in #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Y1KpTKNdop9XoN5RpV2Yh
