### PR TITLE
Select candidates on expected error, not the calibration bound (#140)

### DIFF
--- a/R/evaluation.R
+++ b/R/evaluation.R
@@ -111,10 +111,11 @@ assign_eval_folds <- function(model_data) {
   data.table(cod_localidade_ibge = covered_munis, fold = folds)
 }
 
-# Out-of-fold distance bounds for every covered candidate row: per fold, refit the LightGBM
-# workflow on the other k-1 folds and predict the held-out one, reusing the production
-# model's tuned hyperparameters. Those hyperparameters were tuned on all municipalities,
-# a residual leakage channel deliberately accepted rather than paying for nested tuning.
+# Out-of-fold selection scores and distance bounds for every covered candidate row: per
+# fold, refit both LightGBM workflows on the other k-1 folds and predict the held-out one,
+# reusing each production model's tuned hyperparameters. Those hyperparameters were tuned
+# on all municipalities, a residual leakage channel deliberately accepted rather than
+# paying for nested tuning.
 compute_oof_predictions <- function(model_data, trained_model, fold_assignment) {
   covered <- model_data[!is.na(dist)]
   covered <- merge(covered, fold_assignment, by = "cod_localidade_ibge")
@@ -123,7 +124,8 @@ compute_oof_predictions <- function(model_data, trained_model, fold_assignment) 
     "no covered rows to evaluate" = nrow(covered) > 0
   )
 
-  best_params <- tune::select_best(trained_model$tune_out, metric = "pinball_loss")
+  selection_params <- tune::select_best(trained_model$selection$tune_out, metric = "rmse")
+  bound_params <- tune::select_best(trained_model$bound$tune_out, metric = "pinball_loss")
 
   fold_ids <- sort(unique(covered$fold))
   preds <- vector("list", length(fold_ids))
@@ -141,9 +143,15 @@ compute_oof_predictions <- function(model_data, trained_model, fold_assignment) 
     train_df <- as.data.table(rsample::training(inner))
     cal_df <- as.data.table(rsample::testing(inner))
 
-    wf <- tune::finalize_workflow(build_gbm_workflow(train_df), best_params)
-    fitted_wf <- generics::fit(wf, data = train_df)
-    offset <- conformal_log_offset(fitted_wf, cal_df)
+    selection_wf <- generics::fit(
+      tune::finalize_workflow(build_gbm_workflow(train_df, "regression"), selection_params),
+      data = train_df
+    )
+    bound_wf <- generics::fit(
+      tune::finalize_workflow(build_gbm_workflow(train_df, "quantile"), bound_params),
+      data = train_df
+    )
+    offset <- conformal_log_offset(selection_wf, bound_wf, cal_df)
     message(sprintf(
       "OOF fold %d/%d: fit on %d rows, calibrated on %d (offset %.3f log-km)",
       i,
@@ -154,7 +162,8 @@ compute_oof_predictions <- function(model_data, trained_model, fold_assignment) 
     ))
 
     # test_features is this loop's own materialization, so it is scored in place.
-    test_features[, pred_logq := predict(fitted_wf, new_data = test_features)$.pred]
+    test_features[, pred_logmean := predict(selection_wf, new_data = test_features)$.pred]
+    test_features[, pred_logq := predict(bound_wf, new_data = test_features)$.pred]
     test_features[, conf_dist_km := conformal_bound_km(pred_logq, offset)]
     preds[[i]] <- test_features[, .(
       local_id,
@@ -166,6 +175,7 @@ compute_oof_predictions <- function(model_data, trained_model, fold_assignment) 
       lat,
       dist,
       conf_dist_km,
+      pred_logmean,
       pred_logq,
       fold = f
     )]

--- a/R/model.R
+++ b/R/model.R
@@ -293,15 +293,11 @@ make_model_data <- function(
   add_consensus_features(model_data)
 }
 
-# Build one of the two unfitted tunable LightGBM workflows, sharing one recipe. The
-# pipeline answers two different questions with two models over the same features (#140):
+# Build one of the two unfitted tunable LightGBM workflows, sharing one recipe:
 # "regression" (L2 on log-distance) estimates expected error and ranks candidates for
 # selection; "quantile" predicts the SELECTOR_QUANTILE bound the pipeline publishes.
-# Selecting on the quantile prediction preferred candidates whose error is predictable
-# over candidates whose error is small, costing 2.9 pp of headline accuracy.
+# One model cannot serve both: a quantile fit prefers predictable error over small error.
 build_gbm_workflow <- function(data, objective) {
-  stopifnot(objective %in% c("regression", "quantile"))
-
   ## Define the model recipe
   gbm_recipe <- recipes::recipe(
     formula = log_dist ~ .,
@@ -334,8 +330,10 @@ build_gbm_workflow <- function(data, objective) {
       objective = "quantile",
       alpha = SELECTOR_QUANTILE
     )
-  } else {
+  } else if (objective == "regression") {
     parsnip::set_engine(gbm_spec, "lightgbm", num_leaves = tune(), objective = "regression")
+  } else {
+    stop("unknown objective: ", objective)
   }
 
   workflows::workflow() |>
@@ -378,10 +376,7 @@ pinball_loss.data.frame <- function(data, truth, estimate, na_rm = TRUE, case_we
 
 # The pipeline's pick: one candidate per station, the lowest expected log-distance under
 # the selection model, ties to the first row. Selection, conformal calibration, and
-# evaluation all read it here so they cannot diverge. Keyed on pred_logmean, not the
-# quantile bound: the ranking is invariant to the monotone back-transform, so the
-# geometric-mean bias that disqualifies exp(pred_logmean) as a published estimate is
-# irrelevant here.
+# evaluation all read it here so they cannot diverge.
 select_best_candidate <- function(scored) {
   stopifnot("candidates are missing a selection score" = !anyNA(scored$pred_logmean))
   unique(scored[order(local_id, pred_logmean)], by = "local_id")
@@ -423,37 +418,36 @@ conformal_bound_km <- function(pred_logq, offset) {
   pmax(exp(pred_logq + offset) - GBM_LOG_OFFSET, 0)
 }
 
-# Each model races on the loss its objective trains on; mae on the log scale rides along
-# as a readable companion. Racing uses the first metric.
-tune_metrics_for <- function(objective) {
-  if (objective == "quantile") {
-    list(metrics = yardstick::metric_set(pinball_loss, yardstick::mae), select_on = "pinball_loss")
-  } else {
-    list(metrics = yardstick::metric_set(yardstick::rmse, yardstick::mae), select_on = "rmse")
-  }
-}
-
 # Tune and fit one objective's workflow on the shared split, so the two production models
 # differ in nothing but their objective.
 tune_and_fit <- function(objective, vfolds, splits, grid_n) {
   gbm_workflow <- build_gbm_workflow(rsample::training(splits), objective)
-  m <- tune_metrics_for(objective)
+
+  # Each model races on the loss its objective trains on; mae on the log scale rides
+  # along as a readable companion. Racing uses the first metric.
+  if (objective == "quantile") {
+    metrics <- yardstick::metric_set(pinball_loss, yardstick::mae)
+    select_on <- "pinball_loss"
+  } else {
+    metrics <- yardstick::metric_set(yardstick::rmse, yardstick::mae)
+    select_on <- "rmse"
+  }
 
   gbm_tune <- finetune::tune_race_anova(
     gbm_workflow,
     resamples = vfolds,
     grid = grid_n,
-    metrics = m$metrics,
+    metrics = metrics,
     control = finetune::control_race(
       verbose_elim = TRUE,
       verbose = TRUE,
       allow_par = FALSE
     )
   )
-  best_params <- tune::select_best(gbm_tune, metric = m$select_on)
+  best_params <- tune::select_best(gbm_tune, metric = select_on)
 
   final_model <- tune::finalize_workflow(gbm_workflow, best_params)
-  final_fit <- tune::last_fit(final_model, split = splits, metrics = m$metrics)
+  final_fit <- tune::last_fit(final_model, split = splits, metrics = metrics)
 
   list(tune_out = gbm_tune, final_fit = final_fit)
 }

--- a/R/model.R
+++ b/R/model.R
@@ -12,8 +12,9 @@ library(stringr)
 # shared by the forward transform and both inverse paths so they cannot drift apart.
 GBM_LOG_OFFSET <- 1e-4
 
-# The distance quantile the selector predicts and the pipeline publishes: the exported
-# bound claims the true error falls below it for this share of stations.
+# The distance quantile the bound model predicts and the pipeline publishes: the exported
+# bound claims the true error falls below it for this share of stations. Selection is a
+# different question and uses a different model -- see build_gbm_workflow().
 SELECTOR_QUANTILE <- 0.9
 
 # Earth radius in km, so every haversine distance in this file lands on one scale.
@@ -292,8 +293,14 @@ make_model_data <- function(
   add_consensus_features(model_data)
 }
 
-build_gbm_workflow <- function(data) {
-  # Build the unfitted tunable LightGBM workflow (recipe + spec) used for match selection.
+# Build one of the two unfitted tunable LightGBM workflows, sharing one recipe. The
+# pipeline answers two different questions with two models over the same features (#140):
+# "regression" (L2 on log-distance) estimates expected error and ranks candidates for
+# selection; "quantile" predicts the SELECTOR_QUANTILE bound the pipeline publishes.
+# Selecting on the quantile prediction preferred candidates whose error is predictable
+# over candidates whose error is small, costing 2.9 pp of headline accuracy.
+build_gbm_workflow <- function(data, objective) {
+  stopifnot(objective %in% c("regression", "quantile"))
 
   ## Define the model recipe
   gbm_recipe <- recipes::recipe(
@@ -307,8 +314,6 @@ build_gbm_workflow <- function(data) {
     recipes::update_role(dist, new_role = "id variable") |>
     recipes::step_impute_median(logpop, pct_rural, area)
 
-  ## Quantile objective at SELECTOR_QUANTILE, so the log fit back-transforms to a distance
-  ## quantile rather than a geometric mean.
   gbm_spec <-
     parsnip::boost_tree(
       trees = tune(),
@@ -317,13 +322,21 @@ build_gbm_workflow <- function(data) {
       learn_rate = tune(),
       loss_reduction = tune()
     ) |>
-    parsnip::set_mode("regression") |>
+    parsnip::set_mode("regression")
+
+  ## For the bound model, a quantile fit on the log scale back-transforms to a distance
+  ## quantile rather than a geometric mean.
+  gbm_spec <- if (objective == "quantile") {
     parsnip::set_engine(
+      gbm_spec,
       "lightgbm",
       num_leaves = tune(),
       objective = "quantile",
       alpha = SELECTOR_QUANTILE
     )
+  } else {
+    parsnip::set_engine(gbm_spec, "lightgbm", num_leaves = tune(), objective = "regression")
+  }
 
   workflows::workflow() |>
     workflows::add_recipe(gbm_recipe) |>
@@ -363,13 +376,15 @@ pinball_loss.data.frame <- function(data, truth, estimate, na_rm = TRUE, case_we
   )
 }
 
-# The pipeline's pick: one candidate per station, the lowest predicted quantile, ties to the
-# first row. Selection, conformal calibration, and evaluation all read it here so they cannot
-# diverge. Keyed on pred_logq rather than the kilometre bound, which conformal_bound_km()
-# clamps at 0 and so would tie every near-exact match together.
+# The pipeline's pick: one candidate per station, the lowest expected log-distance under
+# the selection model, ties to the first row. Selection, conformal calibration, and
+# evaluation all read it here so they cannot diverge. Keyed on pred_logmean, not the
+# quantile bound: the ranking is invariant to the monotone back-transform, so the
+# geometric-mean bias that disqualifies exp(pred_logmean) as a published estimate is
+# irrelevant here.
 select_best_candidate <- function(scored) {
-  stopifnot("candidates are missing a predicted quantile" = !anyNA(scored$pred_logq))
-  unique(scored[order(local_id, pred_logq)], by = "local_id")
+  stopifnot("candidates are missing a selection score" = !anyNA(scored$pred_logmean))
+  unique(scored[order(local_id, pred_logmean)], by = "local_id")
 }
 
 # The split-conformal order statistic: given calibration residuals (truth minus predicted
@@ -387,13 +402,15 @@ conformal_offset_from_residuals <- function(resid) {
   sort(resid)[k]
 }
 
-# The conformal correction for a fitted model, on the log scale. Computed on each station's
-# *chosen* candidate rather than all of them: the chosen one is the argmin of the predicted
-# quantile, so it skews toward candidates whose quantile came out too low, and calibrating
-# over every candidate would leave the published number under-covering.
-conformal_log_offset <- function(fitted_workflow, cal_data) {
+# The conformal correction for a fitted bound model, on the log scale. Computed on each
+# station's *chosen* candidate rather than all of them: selection skews toward candidates
+# scored optimistically, and calibrating over every candidate would leave the published
+# number under-covering. The winners are the selection model's picks, because the bound
+# must cover the candidates that actually ship.
+conformal_log_offset <- function(selection_workflow, bound_workflow, cal_data) {
   scored <- as.data.table(cal_data)[, .(local_id, log_dist)]
-  scored[, pred_logq := predict(fitted_workflow, new_data = cal_data)$.pred]
+  scored[, pred_logmean := predict(selection_workflow, new_data = cal_data)$.pred]
+  scored[, pred_logq := predict(bound_workflow, new_data = cal_data)$.pred]
   winners <- select_best_candidate(scored)
   conformal_offset_from_residuals(winners$log_dist - winners$pred_logq)
 }
@@ -406,11 +423,46 @@ conformal_bound_km <- function(pred_logq, offset) {
   pmax(exp(pred_logq + offset) - GBM_LOG_OFFSET, 0)
 }
 
+# Each model races on the loss its objective trains on; mae on the log scale rides along
+# as a readable companion. Racing uses the first metric.
+tune_metrics_for <- function(objective) {
+  if (objective == "quantile") {
+    list(metrics = yardstick::metric_set(pinball_loss, yardstick::mae), select_on = "pinball_loss")
+  } else {
+    list(metrics = yardstick::metric_set(yardstick::rmse, yardstick::mae), select_on = "rmse")
+  }
+}
+
+# Tune and fit one objective's workflow on the shared split, so the two production models
+# differ in nothing but their objective.
+tune_and_fit <- function(objective, vfolds, splits, grid_n) {
+  gbm_workflow <- build_gbm_workflow(rsample::training(splits), objective)
+  m <- tune_metrics_for(objective)
+
+  gbm_tune <- finetune::tune_race_anova(
+    gbm_workflow,
+    resamples = vfolds,
+    grid = grid_n,
+    metrics = m$metrics,
+    control = finetune::control_race(
+      verbose_elim = TRUE,
+      verbose = TRUE,
+      allow_par = FALSE
+    )
+  )
+  best_params <- tune::select_best(gbm_tune, metric = m$select_on)
+
+  final_model <- tune::finalize_workflow(gbm_workflow, best_params)
+  final_fit <- tune::last_fit(final_model, split = splits, metrics = m$metrics)
+
+  list(tune_out = gbm_tune, final_fit = final_fit)
+}
+
 train_model <- function(model_data, dev_mode) {
   # tune_race_anova needs more than its 3 burn-in resamples, so 4 is the dev-mode floor.
   n_folds <- if (dev_mode) 4 else 10
   grid_n <- if (dev_mode) 5 else 50
-  message(sprintf("Training model with %d CV folds and a grid of %d candidates", n_folds, grid_n))
+  message(sprintf("Training models with %d CV folds and a grid of %d candidates each", n_folds, grid_n))
 
   if (nrow(model_data) == 0) {
     stop("No data available for model training")
@@ -439,35 +491,17 @@ train_model <- function(model_data, dev_mode) {
     v = n_folds
   )
 
-  ## Build the tunable workflow (recipe + model spec) from the training data.
-  gbm_workflow <- build_gbm_workflow(training_set)
-
-  ## Hyperparameters are selected on the loss the model is trained on; mae on the log scale
-  ## rides along as a readable companion. Racing uses the first metric.
-  metrics <- yardstick::metric_set(pinball_loss, yardstick::mae)
-
-  ### Use racing models to tune hyperparameters
-  gbm_tune <- finetune::tune_race_anova(
-    gbm_workflow,
-    resamples = vfolds,
-    grid = grid_n,
-    metrics = metrics,
-    control = finetune::control_race(
-      verbose_elim = TRUE,
-      verbose = TRUE,
-      allow_par = FALSE
-    )
-  )
-  best_params <- tune::select_best(gbm_tune, metric = "pinball_loss")
-
-  final_model <- tune::finalize_workflow(gbm_workflow, best_params)
-
-  final_fit <- tune::last_fit(final_model, split = splits, metrics = metrics)
+  selection <- tune_and_fit("regression", vfolds, splits, grid_n)
+  bound <- tune_and_fit("quantile", vfolds, splits, grid_n)
 
   ## last_fit() fits on the training half only, so the testing half is already held out and
   ## serves as the conformal calibration set at no extra fitting cost. Municipality-grouped,
   ## so no station's candidates straddle the fit/calibrate boundary.
-  offset <- conformal_log_offset(tune::extract_workflow(final_fit), testing_set)
+  offset <- conformal_log_offset(
+    tune::extract_workflow(selection$final_fit),
+    tune::extract_workflow(bound$final_fit),
+    testing_set
+  )
   message(sprintf(
     "Conformal offset for %.0f%% coverage: %.3f log-km over %d calibration stations",
     100 * SELECTOR_QUANTILE,
@@ -476,17 +510,19 @@ train_model <- function(model_data, dev_mode) {
   ))
 
   list(
-    tune_out = gbm_tune,
-    final_fit = final_fit,
+    selection = selection,
+    bound = bound,
     conformal_offset = offset
   )
 }
 
-# Score every candidate match and attach its calibrated distance bound in kilometres.
+# Score every candidate match under both models: the selection score that ranks candidates
+# and the calibrated distance bound in kilometres that ships with the winner.
 # Projects first and predicts into the narrow table: model_data carries every predictor and
 # runs to millions of rows, so scoring it in place would double the target's peak memory.
 get_predictions <- function(trained_model, model_data) {
-  fitted <- tune::extract_workflow(trained_model$final_fit)
+  selection_wf <- tune::extract_workflow(trained_model$selection$final_fit)
+  bound_wf <- tune::extract_workflow(trained_model$bound$final_fit)
   out <- model_data[, .(
     local_id,
     match_type = type,
@@ -496,7 +532,8 @@ get_predictions <- function(trained_model, model_data) {
     lat,
     dist
   )]
-  out[, pred_logq := predict(fitted, new_data = model_data)$.pred]
+  out[, pred_logmean := predict(selection_wf, new_data = model_data)$.pred]
+  out[, pred_logq := predict(bound_wf, new_data = model_data)$.pred]
   out[, conf_dist_km := conformal_bound_km(pred_logq, trained_model$conformal_offset)]
   out[]
 }

--- a/tests/testthat/test-conformal.R
+++ b/tests/testthat/test-conformal.R
@@ -80,7 +80,7 @@ test_that("select_best_candidate keeps one lowest-expected-error candidate per s
   )
 
   # Selection must ignore the quantile bound when the selection score disagrees with
-  # it: ranking on the bound is the #140 regression.
+  # it: ranking on the bound would ship predictable-error candidates over small-error ones.
   two_scores <- data.table(
     local_id = c("l1", "l1"),
     type = c("small_error", "predictable_error"),

--- a/tests/testthat/test-conformal.R
+++ b/tests/testthat/test-conformal.R
@@ -1,7 +1,7 @@
 ## Spec tests for the calibrated distance bound (R/model.R): the pinball loss the
-## selector is trained and tuned on, the conformal order statistic that turns a
+## bound model is trained and tuned on, the conformal order statistic that turns a
 ## predicted quantile into a bound with finite-sample coverage, the back-transform
-## to kilometres, and the per-station candidate pick all three feed.
+## to kilometres, and the per-station candidate pick the selection model drives.
 
 library(testthat)
 library(data.table)
@@ -61,21 +61,31 @@ test_that("conformal_bound_km inverts the log transform and never goes negative"
   expect_equal(conformal_bound_km(log(GBM_LOG_OFFSET), -5), 0)
 })
 
-test_that("select_best_candidate keeps one lowest-bound candidate per station", {
+test_that("select_best_candidate keeps one lowest-expected-error candidate per station", {
   scored <- data.table(
     local_id = c("l1", "l1", "l1", "l2", "l2"),
     type = c("a", "b", "c", "a", "b"),
-    pred_logq = c(2.0, 0.5, 1.0, 3.0, 3.0)
+    pred_logmean = c(2.0, 0.5, 1.0, 3.0, 3.0)
   )
   best <- select_best_candidate(scored)
   expect_equal(nrow(best), 2L)
-  expect_equal(best[local_id == "l1"]$type, "b") # smallest predicted quantile
+  expect_equal(best[local_id == "l1"]$type, "b") # smallest expected log-distance
   expect_equal(best[local_id == "l2"]$type, "a") # tie -> first row
 
   # An unscored candidate must error: it would sort ahead of or behind every real
   # one depending on the sort, silently changing which coordinate ships.
   expect_error(
-    select_best_candidate(data.table(local_id = "l1", pred_logq = NA_real_)),
-    "missing a predicted quantile"
+    select_best_candidate(data.table(local_id = "l1", pred_logmean = NA_real_)),
+    "missing a selection score"
   )
+
+  # Selection must ignore the quantile bound when the selection score disagrees with
+  # it: ranking on the bound is the #140 regression.
+  two_scores <- data.table(
+    local_id = c("l1", "l1"),
+    type = c("small_error", "predictable_error"),
+    pred_logmean = c(0.5, 1.0),
+    pred_logq = c(4.0, 1.5)
+  )
+  expect_equal(select_best_candidate(two_scores)$type, "small_error")
 })


### PR DESCRIPTION
## What this PR does

The pipeline picks one coordinate per polling station from several candidates, using a model trained on ground truth. Since #44, that model predicted a *worst-case* error (a 90th-percentile bound, needed for the published confidence column), and the pipeline picked the candidate with the lowest worst-case error. That choice favors candidates whose error is predictable over candidates whose error is small, and it cost 2.9 points of headline accuracy on the 2026-08-10 run (#140). This PR gives each job its own model: one that estimates *expected* error and does the picking, and the existing worst-case model that keeps producing the published confidence bound.

## Changes

- `build_gbm_workflow()` takes an `objective` and builds either model from one shared recipe; unknown objectives fail loud.
- `train_model()` tunes and fits both via one `tune_and_fit()` helper — selection races on `rmse`, bound on `pinball_loss`, over the same folds and split.
- `select_best_candidate()` orders on the selection model's `pred_logmean`; everything downstream (`finalize_coords()`, OOF evaluation, conformal calibration) reads it from there.
- `conformal_log_offset()` calibrates the bound on the winners the **selection** model picks, so published coverage tracks what actually ships.
- `compute_oof_predictions()` refits both models per fold and emits both scores.
- Selection tests updated, plus a new case pinning that selection ignores the bound when the two scores disagree.

## Evidence

Measured on the production store with the OOF harness — same folds, features, and DF-excluded universe (n = 257,339) as the shipped numbers (full protocol in [the #140 comment](https://github.com/fdhidalgo/geocode_br_polling_stations/issues/140#issuecomment-5252710194)):

| | 08-10 shipped (quantile select) | L2 select (this design) |
|---|---|---|
| within 500 m | 78.03% | **82.02%** |
| median | 41.7 m | **32.2 m** |
| p90 | 3.64 km | **2.13 km** |
| rural:Sul within 500 m | 34.81% | **41.05%** |

That beats the 08-06 run (80.9% / 34 m / 2.68 km) on every headline metric, and rural:Sul returns above the frozen v0.15 baseline (35.7%). The measurement reused pinball-tuned hyperparameters for the L2 fits, so it slightly understates this PR (which tunes each model on its own loss).

Validation: 332 unit tests pass; dev-mode pipeline (AC/RR) runs end to end with all release gates green, conformal coverage 90.1% against nominal 90%.

## Cost and knock-ons

- Production training roughly doubles (a second racing tune); OOF evaluation fits 10 models instead of 5 (~2x of 140 s).
- **Adoption still requires the confirming national run**, reported against the 08-06 numbers per the gate.
- At adoption, update in lockstep: `doc/geocoding_procedure.qmd` (its `best_prediction` block still describes smallest-bound selection, and never matched `finalize_coords()` exactly) and the "smallest bound" language in `docs/specs/2026-07-evaluation-spec.md`.
- Panel coordinate selection still ranks on `conf_dist_km` — same inversion, scoped follow-up: #142.

Review: full tier (changes which coordinate ships for every station) — Codex layer plus Opus subagent review ran; fixes applied in the second commit, panel finding filed as #142.

Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)