### PR TITLE
Rank panel coordinates on expected error, not the published bound

### DIFF
--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -430,12 +430,15 @@ finalize_coords <- function(locais, model_predictions, tsegeocoded_locais) {
   geocoded_locais[, final_lat := ifelse(is.na(tse_lat), pred_lat, tse_lat)]
 
   # conf_dist_km bounds the error of the chosen coordinate and final_logmean is that
-  # error's expected value on the model's log scale; a TSE coordinate is the
-  # field-collected truth, so both take their zero-error values. final_logmean is
-  # internal: it ranks a panel's station-years in make_panel_ids() and is dropped at export.
+  # error's expected value on the log scale; a TSE coordinate is the field-collected
+  # truth, so its error is zero and log(0) is -Inf. The infinity is load-bearing, not
+  # decorative: make_panel_ids() ranks a panel's station-years on final_logmean, and the
+  # LightGBM prediction is unconstrained, so any finite floor could in principle be
+  # undercut by a model candidate and hand a panel a model coordinate over ground truth.
+  # final_logmean is internal and dropped at export.
   geocoded_locais[
     !is.na(tse_long) & !is.na(tse_lat),
-    c("conf_dist_km", "final_logmean") := .(0, log(GBM_LOG_OFFSET))
+    c("conf_dist_km", "final_logmean") := .(0, -Inf)
   ]
 
   return(geocoded_locais)

--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -397,7 +397,7 @@ import_locais <- function(locais_file, muni_ids) {
 
 # Attaches the best model prediction and TSE ground truth, then picks each station's final coords.
 finalize_coords <- function(locais, model_predictions, tsegeocoded_locais) {
-  best_match <- select_best_candidate(model_predictions)[, .(local_id, long, lat, conf_dist_km)]
+  best_match <- select_best_candidate(model_predictions)[, .(local_id, long, lat, conf_dist_km, pred_logmean)]
 
   geocoded_locais <- merge(
     locais,
@@ -413,7 +413,11 @@ finalize_coords <- function(locais, model_predictions, tsegeocoded_locais) {
       "normalized_bairro"
     ) := NULL
   ]
-  setnames(geocoded_locais, c("long", "lat"), c("pred_long", "pred_lat"))
+  setnames(
+    geocoded_locais,
+    c("long", "lat", "pred_logmean"),
+    c("pred_long", "pred_lat", "final_logmean")
+  )
 
   geocoded_locais <- merge(
     geocoded_locais,
@@ -425,9 +429,14 @@ finalize_coords <- function(locais, model_predictions, tsegeocoded_locais) {
   geocoded_locais[, final_long := ifelse(is.na(tse_long), pred_long, tse_long)]
   geocoded_locais[, final_lat := ifelse(is.na(tse_lat), pred_lat, tse_lat)]
 
-  # conf_dist_km bounds the error of the chosen coordinate; a TSE coordinate is the
-  # field-collected truth, so its bound is zero.
-  geocoded_locais[!is.na(tse_long) & !is.na(tse_lat), conf_dist_km := 0]
+  # conf_dist_km bounds the error of the chosen coordinate and final_logmean is that
+  # error's expected value on the model's log scale; a TSE coordinate is the
+  # field-collected truth, so both take their zero-error values. final_logmean is
+  # internal: it ranks a panel's station-years in make_panel_ids() and is dropped at export.
+  geocoded_locais[
+    !is.na(tse_long) & !is.na(tse_lat),
+    c("conf_dist_km", "final_logmean") := .(0, log(GBM_LOG_OFFSET))
+  ]
 
   return(geocoded_locais)
 }

--- a/R/evaluation.R
+++ b/R/evaluation.R
@@ -609,7 +609,12 @@ compute_panel_coord_accuracy <- function(
   )
   members <- merge(members, picks, by = "local_id")
   members <- merge(members, tsegeocoded_locais[, .(local_id, tse_long, tse_lat)], by = "local_id")
-  stopifnot("no covered panel members to score" = nrow(members) > 0)
+  # A station in two panels would fan out the joins below into cross-panel coordinate
+  # pairs -- one rule's coordinate from one panel scored against the other's from another.
+  stopifnot(
+    "no covered panel members to score" = nrow(members) > 0,
+    "a station belongs to more than one panel" = !anyDuplicated(members$local_id)
+  )
 
   # One rule's panel coordinate handed to every member, and each member's error under it.
   # The ordering mirrors make_panel_ids(): rank column first, ties to the most recent year.

--- a/R/evaluation.R
+++ b/R/evaluation.R
@@ -568,6 +568,110 @@ compare_geocodebr_to_model <- function(geocodebr_selected_matches, oof_selected_
   out[]
 }
 
+# Metric columns of the panel-coordinate comparison, suppressed below the cell-size floor.
+EVAL_PANEL_COLS <- c(
+  "median_km_bound",
+  "median_km_expected",
+  "delta_median_km",
+  "within_500m_bound",
+  "within_500m_expected",
+  "delta_within_500m"
+)
+
+# Panel coordinate accuracy under the two candidate ranking rules: lowest expected error
+# (what the pipeline ships) against smallest published bound (what it shipped before).
+# A panel gives one coordinate to all of its station-years, so the quantity measured here
+# is that single coordinate against every member's TSE ground truth -- a different question
+# from the station-level tables above, which score each station-year's own pick.
+#
+# Scored on out-of-fold model coordinates with no TSE substitution, deliberately: in
+# production a panel holding any covered year ships ground truth under either rule, so the
+# rules can only diverge on panels with no covered year at all -- exactly the panels that
+# have no truth to be measured against. Withholding the substitution lets the covered
+# panels stand in for them.
+#
+# Members outside the covered universe have no out-of-fold coordinate, so they neither
+# compete for the panel coordinate nor are scored; a panel enters with the covered years
+# it has. Deltas are expected-error minus bound, so the shipped rule's advantage reads as
+# a negative median delta and a positive within-500 m delta.
+compute_panel_coord_accuracy <- function(
+  panel_ids_combined,
+  oof_predictions,
+  eval_station_universe,
+  tsegeocoded_locais
+) {
+  picks <- select_best_candidate(oof_predictions)[, .(local_id, long, lat, pred_logmean, conf_dist_km)]
+
+  members <- merge(
+    as.data.table(panel_ids_combined)[, .(local_id, panel_id)],
+    eval_station_universe[, .(local_id, vintage, urban_rural, region)],
+    by = "local_id"
+  )
+  members <- merge(members, picks, by = "local_id")
+  members <- merge(members, tsegeocoded_locais[, .(local_id, tse_long, tse_lat)], by = "local_id")
+  stopifnot("no covered panel members to score" = nrow(members) > 0)
+
+  # One rule's panel coordinate handed to every member, and each member's error under it.
+  # The ordering mirrors make_panel_ids(): rank column first, ties to the most recent year.
+  under_rule <- function(rank_col) {
+    best <- unique(
+      members[order(panel_id, get(rank_col), -vintage)],
+      by = "panel_id"
+    )[, .(panel_id, sel_long = long, sel_lat = lat)]
+    out <- merge(members[, .(local_id, panel_id, tse_long, tse_lat)], best, by = "panel_id")
+    out[, .(
+      local_id,
+      sel_long,
+      sel_lat,
+      error_km = geosphere::distHaversine(
+        cbind(sel_long, sel_lat),
+        cbind(tse_long, tse_lat),
+        r = EARTH_RADIUS_KM
+      )
+    )]
+  }
+
+  expected <- under_rule("pred_logmean")
+  bound <- under_rule("conf_dist_km")
+  setnames(expected, c("sel_long", "sel_lat", "error_km"), c("long_e", "lat_e", "error_km_expected"))
+  setnames(bound, c("sel_long", "sel_lat", "error_km"), c("long_b", "lat_b", "error_km_bound"))
+
+  paired <- merge(
+    members[, .(local_id, panel_id, urban_rural, region, vintage)],
+    merge(expected, bound, by = "local_id"),
+    by = "local_id"
+  )
+  paired[, changed := long_e != long_b | lat_e != lat_b]
+
+  cell <- function(dt) {
+    e <- accuracy_metrics(dt$error_km_expected)
+    b <- accuracy_metrics(dt$error_km_bound)
+    list(
+      n_stations = nrow(dt),
+      n_panels = uniqueN(dt$panel_id),
+      # How often the two rules disagree at all: the metric deltas below are diluted by
+      # every station-year where both rules ship the same coordinate.
+      pct_changed = 100 * mean(dt$changed),
+      median_km_bound = b$median_km,
+      median_km_expected = e$median_km,
+      delta_median_km = e$median_km - b$median_km,
+      within_500m_bound = b$within_500m,
+      within_500m_expected = e$within_500m,
+      delta_within_500m = e$within_500m - b$within_500m
+    )
+  }
+
+  out <- rbindlist(
+    lapply(
+      list(character(0), "urban_rural", "region", "vintage"),
+      function(s) .by_stratum(paired, s, cell, metric_cols = EVAL_PANEL_COLS, n_col = "n_stations")
+    ),
+    use.names = TRUE
+  )
+  setcolorder(out, c("stratum", "level", "n_stations", "n_panels", "pct_changed"))
+  out[]
+}
+
 # Metric columns of the coverage tables, suppressed together below the cell-size floor.
 EVAL_COVERAGE_COLS <- c("coverage", "median_bound_km", "median_error_km")
 

--- a/R/panel_creation.R
+++ b/R/panel_creation.R
@@ -67,8 +67,8 @@ make_panel_ids <- function(panel_ids_combined, geocoded_locais) {
   standardize_column_names(panel_ids_combined)
 
   # Attach each station-year's final coordinate, its expected error, and its published
-  # bound. final_logmean holds the zero-error value for TSE-covered rows, so ordering by
-  # it puts ground-truth coordinates ahead of model ones.
+  # bound. final_logmean is -Inf for TSE-covered rows, so ordering by it puts ground-truth
+  # coordinates ahead of every model one, and ties among them fall to the year rule below.
   panel_ids <- geocoded_locais[
     panel_ids_combined,
     on = .(local_id),

--- a/R/panel_creation.R
+++ b/R/panel_creation.R
@@ -66,24 +66,32 @@ make_panel_ids <- function(panel_ids_combined, geocoded_locais) {
   # shared in-memory object other consumers (export, release gates) read.
   standardize_column_names(panel_ids_combined)
 
-  # Attach each station-year's final coordinate and distance bound. conf_dist_km is 0 for
-  # TSE-covered rows, so ordering by it puts ground-truth coordinates ahead of model ones.
+  # Attach each station-year's final coordinate, its expected error, and its published
+  # bound. final_logmean holds the zero-error value for TSE-covered rows, so ordering by
+  # it puts ground-truth coordinates ahead of model ones.
   panel_ids <- geocoded_locais[
     panel_ids_combined,
     on = .(local_id),
     nomatch = NA
-  ][, .(local_id, panel_id, ano, long = final_long, lat = final_lat, conf_dist_km)]
+  ][, .(local_id, panel_id, ano, long = final_long, lat = final_lat, conf_dist_km, final_logmean)]
 
-  # One coordinate per panel: smallest bound, ties to the most recent year. Only
+  # One coordinate per panel: lowest expected error, ties to the most recent year. Ranking
+  # on final_logmean rather than the published conf_dist_km matches how each station-year's
+  # own coordinate was picked -- the bound is a calibrated upper bound, so ordering by it
+  # prefers a coordinate whose error is predictable over one whose error is small. Only
   # station-years carrying a coordinate compete, so a panel comes out blank only when
   # every year failed to geocode. unique(by=) takes the first row of the sorted table.
+  geocoded_years <- panel_ids[!is.na(long) & !is.na(lat)]
+  stopifnot(
+    "a geocoded station-year reached panel selection without an expected error" = !anyNA(geocoded_years$final_logmean)
+  )
   panel_ids_best <- unique(
-    panel_ids[!is.na(long) & !is.na(lat)][order(panel_id, conf_dist_km, -ano)],
+    geocoded_years[order(panel_id, final_logmean, -ano)],
     by = "panel_id"
   )[, .(panel_id, long, lat, conf_dist_km)]
 
   # Swap the per-station coordinates for the chosen panel-level one.
-  panel_ids[, c("long", "lat", "conf_dist_km", "ano") := NULL]
+  panel_ids[, c("long", "lat", "conf_dist_km", "final_logmean", "ano") := NULL]
   panel_ids <- panel_ids_best[
     panel_ids,
     on = .(panel_id),

--- a/R/validation.R
+++ b/R/validation.R
@@ -2,10 +2,12 @@
 
 library(data.table)
 
-# The exact geocoded_locais schema written to geocoded_polling_stations.csv.gz, in the
-# order finalize_coords() produces it. Checked twice: validate_final_output() requires
-# every column before the export runs, release Gate 2 asserts set equality after it.
-RELEASE_EXPORT_COLS <- c(
+# The exact geocoded_locais schema, in the order finalize_coords() produces it. Checked
+# twice: validate_final_output() requires every column before the export runs, release
+# Gate 2 asserts set equality after it. This is the internal table, not the published
+# file: to_geocoded_export_schema() drops final_logmean and renames final_long/final_lat,
+# and Gate 9 checks that published header against GEOCODED_EXPORT_SCHEMA.
+GEOCODED_TABLE_COLS <- c(
   "cd_localidade_tse",
   "ano",
   "nr_zona",
@@ -21,6 +23,9 @@ RELEASE_EXPORT_COLS <- c(
   "pred_long",
   "pred_lat",
   "conf_dist_km",
+  # Internal: the expected error of the shipped coordinate, which make_panel_ids() ranks
+  # a panel's station-years on. Dropped at export.
+  "final_logmean",
   "tse_lat",
   "tse_long",
   "final_long",
@@ -52,7 +57,7 @@ validate_model_predictions <- function(predictions) {
 # Asserts the final geocoded table is shippable; stops before export on failure.
 validate_final_output <- function(output_data) {
   stopifnot(nrow(output_data) > 0)
-  missing_cols <- setdiff(RELEASE_EXPORT_COLS, names(output_data))
+  missing_cols <- setdiff(GEOCODED_TABLE_COLS, names(output_data))
   if (length(missing_cols) > 0) {
     stop(sprintf("geocoded_locais is missing required columns: %s", paste(missing_cols, collapse = ", ")))
   }
@@ -274,8 +279,8 @@ validate_release_gates <- function(
   }
 
   # Gate 2: exported schema exactly unchanged - no column removed or added.
-  missing_cols <- setdiff(RELEASE_EXPORT_COLS, names(dt))
-  extra_cols <- setdiff(names(dt), RELEASE_EXPORT_COLS)
+  missing_cols <- setdiff(GEOCODED_TABLE_COLS, names(dt))
+  extra_cols <- setdiff(names(dt), GEOCODED_TABLE_COLS)
   if (length(missing_cols) > 0) {
     add_fail("Gate 2 (schema): missing columns: %s", paste(missing_cols, collapse = ", "))
   }

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Subsequently, we use the Fellegi-Sunter framework for record linkage to choose t
 
 - `panel_id`: unique panel identifier. Units with the same `panel_id` are classified to be the same polling station in two different election years according to our fuzzy matching procedure. 
 - `local_id`: polling station identifier. Use this variable to merge with the coordinates data (one `local_id` per polling-station-election, so it also identifies the election year via that join). 
-- `long`: This is a longitude variable that is constant for all observations with the same `panel_id` across years. To choose among coordinates from different years, we select the one with the smallest `conf_dist_km`. Ties are broken by selecting the longitude from the latest year.
-- `lat`: This is a latitude variable that is constant for all observations with the same `panel_id` across years. To choose among coordinates from different years, we select the one with the smallest `conf_dist_km`. Ties are broken by selecting the latitude from the latest year.
-- `conf_dist_km`: The distance bound of the chosen coordinate, defined as in the coordinates file above. Constant within a `panel_id`, since the whole panel shares one coordinate.
+- `long`: This is a longitude variable that is constant for all observations with the same `panel_id` across years. To choose among coordinates from different years, we select the one whose expected error is smallest, the same criterion used to pick each polling station's own coordinate. A TSE-provided coordinate, being field-collected, always wins. Ties are broken by selecting the longitude from the latest year.
+- `lat`: This is a latitude variable that is constant for all observations with the same `panel_id` across years. Chosen by the same rule as `long`, and from the same year.
+- `conf_dist_km`: The distance bound of the chosen coordinate, defined as in the coordinates file above. Constant within a `panel_id`, since the whole panel shares one coordinate. It is the bound of the year that was selected, which is not necessarily the smallest bound in the panel — the selection ranks on expected error, not on the bound.
 
 ## Development Setup
 

--- a/_targets.R
+++ b/_targets.R
@@ -949,6 +949,19 @@ list(
     command = compute_calibration(oof_selected_matches)
   ),
 
+  ## Panel coordinate quality: the ranking rule the panel ships on against the published
+  ## bound it replaced, both scored on every panel member's ground truth.
+  tar_target(
+    name = panel_coord_accuracy,
+    command = compute_panel_coord_accuracy(
+      panel_ids_combined,
+      oof_predictions,
+      eval_station_universe,
+      tsegeocoded_locais
+    ),
+    format = "qs"
+  ),
+
   ## Thin Quarto report rendering the evaluation targets for human reading.
   tar_render(
     name = evaluation_report,

--- a/docs/specs/2026-07-evaluation-spec.md
+++ b/docs/specs/2026-07-evaluation-spec.md
@@ -345,7 +345,9 @@ upper bound, so ranking on it prefers a coordinate whose error is *predictable* 
 error is *small*. Members are now ranked on expected error (`final_logmean`, the selection
 model's prediction for the coordinate that shipped, threaded through `geocoded_locais` as an
 internal column). Ties still break toward the most recent year, and a TSE-covered year still
-sorts first — it carries the zero-error value of `final_logmean`, as it carries `conf_dist_km = 0`.
+sorts first: its error is zero, so its `final_logmean` is `log(0)` — `-Inf`, the same way its
+`conf_dist_km` is 0. The infinity is deliberate. A finite floor would make ground-truth
+precedence depend on no LightGBM prediction ever falling below it, which nothing enforces.
 
 **The measurement.** `compute_panel_coord_accuracy()` runs both rules over the same panels and
 scores each rule's panel coordinate against **every covered member's** TSE coordinate, on the

--- a/docs/specs/2026-07-evaluation-spec.md
+++ b/docs/specs/2026-07-evaluation-spec.md
@@ -331,6 +331,39 @@ tables are what currently carry the stations that fall to coarser rungs.
 
 ---
 
+## 7c. Panel coordinate quality (added by [#142](https://github.com/fdhidalgo/geocode_br_polling_stations/issues/142))
+
+Everything above scores a station-year against its own ground truth. A panel is a different
+object: it links one polling station across elections and publishes a **single** coordinate
+that all of its station-years inherit. So it makes its own selection — which member year's
+coordinate to hand to the rest — and that choice needs its own measurement, because a panel
+coordinate is wrong at a member year whenever the year it came from was wrong.
+
+**What changed.** `make_panel_ids()` ranked members on the published `conf_dist_km`. That is
+the same inversion §1's amendment describes at the candidate level: the bound is a calibrated
+upper bound, so ranking on it prefers a coordinate whose error is *predictable* over one whose
+error is *small*. Members are now ranked on expected error (`final_logmean`, the selection
+model's prediction for the coordinate that shipped, threaded through `geocoded_locais` as an
+internal column). Ties still break toward the most recent year, and a TSE-covered year still
+sorts first — it carries the zero-error value of `final_logmean`, as it carries `conf_dist_km = 0`.
+
+**The measurement.** `compute_panel_coord_accuracy()` runs both rules over the same panels and
+scores each rule's panel coordinate against **every covered member's** TSE coordinate, on the
+§4a ladder, cut overall and by the §4b axes. Delta orientation follows §7b's rule: the subject
+is the shipped rule, so the delta is expected-error minus bound.
+
+**Why it withholds the TSE substitution.** It scores out-of-fold *model* coordinates only. In
+production, a panel holding any covered year ships that year's ground truth under either rule,
+so the two rules can only diverge on panels with **no** covered year — precisely the panels
+with no truth to measure. Withholding the substitution makes the covered panels stand in for
+the uncovered ones; it is the same extrapolation §1 makes for stations, one level up.
+
+**Reading it.** The table reports the share of station-years whose shipped coordinate actually
+differs between the rules. Every station-year where the rules agree dilutes the metric deltas
+toward zero, so the deltas are only interpretable against that share.
+
+---
+
 ## 8. The Google reference-validation (covered-only this round)
 
 Purpose: quantify **Google's own error budget** relative to field-GPS TSE *before*

--- a/reports/evaluation_report.qmd
+++ b/reports/evaluation_report.qmd
@@ -36,7 +36,8 @@ tar_load(c(
   baseline_comparison,
   geocodebr_accuracy_tables,
   geocodebr_vs_model,
-  calibration_check
+  calibration_check,
+  panel_coord_accuracy
 ))
 
 acc <- as.data.table(accuracy_tables)
@@ -44,6 +45,7 @@ cov <- as.data.table(tse_coverage)
 cmp <- as.data.table(baseline_comparison)
 gb_acc <- as.data.table(geocodebr_accuracy_tables)
 gb_cmp <- as.data.table(geocodebr_vs_model)
+pc <- as.data.table(panel_coord_accuracy)
 
 # One formatter per table schema, so every rendering of a schema agrees on decimals,
 # labels and spanners. Each caller adds only its own filter, counts and notes.
@@ -422,6 +424,86 @@ ggplot(rf, aes(x = drop_frac)) +
   labs(x = "Fraction of widest-bound stations dropped",
        y = "Realized median error (km)",
        title = "Dropping the widest-bound tail lowers realized error")
+```
+
+## Panel coordinates: which station-year should a panel ship?
+
+A panel is one polling station tracked across elections, and it publishes a **single**
+coordinate that every one of its station-years inherits. So the panel has its own
+selection problem: which member year's coordinate to hand to the rest. The pipeline ranks
+members on expected error, the same quantity that picks each station-year's own
+coordinate; before issue #142 it ranked them on the published `conf_dist_km` bound, which
+prefers a coordinate whose error is *predictable* over one whose error is *small*.
+
+This table scores both rules on ground truth: each rule's panel coordinate measured
+against every covered member's TSE coordinate. Two things to read carefully.
+
+- It runs on **out-of-fold model coordinates with no TSE substitution**. In production a
+  panel holding any covered year ships that year's ground truth under either rule, so the
+  rules can only diverge on panels with **no** covered year — the panels with no truth to
+  measure. Withholding the substitution makes the covered panels stand in for them.
+- `Changed %` is the share of station-years whose shipped coordinate differs between the
+  rules. The metric deltas are diluted by every station-year where both rules agree, so
+  read them against it.
+
+**Δ is expected-error minus bound**, so the shipped rule's advantage is a negative median Δ
+and a positive `<500 m` Δ.
+
+```{r}
+#| label: panel-coord-headline
+#| output: asis
+pc_overall <- pc[stratum == "overall"]
+cat(sprintf(
+  paste0(
+    "**Panel coordinates (covered members, out-of-fold):** the two rules ship a different ",
+    "coordinate for **%.1f%%** of **%s** station-years across **%s** panels. ",
+    "Median error **%.3f km** (expected error) vs **%.3f km** (bound), **%+.3f km**. ",
+    "Within 500 m: **%.1f%%** vs **%.1f%%**, **%+.1f pp**."
+  ),
+  pc_overall$pct_changed,
+  format(pc_overall$n_stations, big.mark = ","),
+  format(pc_overall$n_panels, big.mark = ","),
+  pc_overall$median_km_expected, pc_overall$median_km_bound, pc_overall$delta_median_km,
+  pc_overall$within_500m_expected, pc_overall$within_500m_bound, pc_overall$delta_within_500m
+))
+```
+
+```{r}
+#| label: panel-coord-table
+pc |>
+  gt(groupname_col = "stratum", rowname_col = "level") |>
+  fmt_number(
+    columns = c("median_km_bound", "median_km_expected", "delta_median_km"),
+    decimals = 3
+  ) |>
+  fmt_number(
+    columns = c("pct_changed", "within_500m_bound", "within_500m_expected", "delta_within_500m"),
+    decimals = 1
+  ) |>
+  fmt_integer(columns = c("n_stations", "n_panels")) |>
+  sub_missing(missing_text = "—") |>
+  cols_label(
+    n_stations = "N station-years", n_panels = "N panels", pct_changed = "Changed %",
+    median_km_bound = "Bound", median_km_expected = "Expected error",
+    delta_median_km = "Δ",
+    within_500m_bound = "Bound", within_500m_expected = "Expected error",
+    delta_within_500m = "Δ", suppressed = "Below N floor"
+  ) |>
+  tab_spanner(
+    label = "Median error (km)",
+    columns = c("median_km_bound", "median_km_expected", "delta_median_km")
+  ) |>
+  tab_spanner(
+    label = "Within 500 m (%)",
+    columns = c("within_500m_bound", "within_500m_expected", "delta_within_500m")
+  ) |>
+  tab_header(
+    title = "Panel coordinate accuracy by ranking rule",
+    subtitle = "Each rule's panel coordinate scored against every covered member's TSE coordinate"
+  ) |>
+  tab_source_note(
+    "Δ is expected-error minus bound: negative median and positive <500 m favour the shipped rule."
+  )
 ```
 
 ## Google reference-validation (spec section 8)

--- a/tests/testthat/test-evaluation.R
+++ b/tests/testthat/test-evaluation.R
@@ -292,6 +292,71 @@ test_that("compare_geocodebr_to_model scores both selectors on both-geocoded sta
   expect_error(compare_geocodebr_to_model(gb[-1L], model), "different station universes")
 })
 
+## Fixture for compute_panel_coord_accuracy(): `n_panels` two-year panels, all covered.
+## Both members sit at the same truth. The 2018 member's out-of-fold coordinate is exact
+## but carries the wide bound; the 2022 member's is ~1.1 km off with a tight bound, so the
+## two ranking rules pick opposite years unless `agree` flips the bounds.
+panel_accuracy_fixture <- function(n_panels = 30L, agree = FALSE) {
+  n <- 2L * n_panels
+  ids <- seq_len(n)
+  first <- rep(c(TRUE, FALSE), n_panels)
+  truth_long <- rep(-60 + seq_len(n_panels) / 100, each = 2L)
+  list(
+    panel_ids_combined = data.table(
+      local_id = ids,
+      panel_id = rep(sprintf("p%02d", seq_len(n_panels)), each = 2L)
+    ),
+    oof_predictions = data.table(
+      local_id = ids,
+      long = truth_long,
+      lat = fifelse(first, -9, -9 + 0.01),
+      pred_logmean = fifelse(first, -2, -1),
+      conf_dist_km = if (agree) fifelse(first, 0.5, 4) else fifelse(first, 4, 0.5)
+    ),
+    eval_station_universe = data.table(
+      local_id = ids,
+      vintage = fifelse(first, 2018L, 2022L),
+      urban_rural = "urban",
+      region = "Norte"
+    ),
+    tsegeocoded_locais = data.table(
+      local_id = ids,
+      tse_long = truth_long,
+      tse_lat = -9
+    )
+  )
+}
+
+test_that("compute_panel_coord_accuracy scores both ranking rules on panel members", {
+  fx <- panel_accuracy_fixture()
+  out <- do.call(compute_panel_coord_accuracy, fx)
+
+  overall <- out[stratum == "overall"]
+  expect_equal(overall$n_stations, 60L)
+  expect_equal(overall$n_panels, 30L)
+  # Every panel ships a different coordinate under the two rules.
+  expect_equal(overall$pct_changed, 100)
+
+  # Expected error picks the exact 2018 coordinate for the whole panel; the bound picks
+  # the 2022 one, which misses both members by ~1.1 km.
+  expect_equal(overall$median_km_expected, 0)
+  expect_equal(overall$median_km_bound, 1.11, tolerance = 0.01)
+  expect_lt(overall$delta_median_km, 0) # shipped rule closer to truth
+  expect_equal(overall$within_500m_expected, 100)
+  expect_equal(overall$within_500m_bound, 0)
+  expect_equal(overall$delta_within_500m, 100)
+
+  # Every member is scored, including the year whose own coordinate did not win.
+  expect_equal(out[stratum == "vintage", sum(n_stations)], 60L)
+})
+
+test_that("compute_panel_coord_accuracy reports no change when the rules agree", {
+  out <- do.call(compute_panel_coord_accuracy, panel_accuracy_fixture(agree = TRUE))
+  overall <- out[stratum == "overall"]
+  expect_equal(overall$pct_changed, 0)
+  expect_equal(overall$delta_median_km, 0)
+})
+
 test_that("compute_accuracy_tables reports match rate and suppresses small cells", {
   dt <- data.table(
     local_id = 1:8,

--- a/tests/testthat/test-finalize_coords.R
+++ b/tests/testthat/test-finalize_coords.R
@@ -3,7 +3,7 @@
 ## final_logmean (expected error on the model's log scale, internal, and what
 ## make_panel_ids() ranks a panel's station-years on).
 
-test_that("finalize_coords carries the winner's expected error and zeroes it for TSE rows", {
+test_that("finalize_coords carries the winner's expected error and floors it for TSE rows", {
   locais <- data.table::data.table(
     local_id = c(1L, 2L),
     ano = c(2018L, 2022L),
@@ -38,13 +38,13 @@ test_that("finalize_coords carries the winner's expected error and zeroes it for
   expect_equal(out[local_id == 1L, conf_dist_km], 1.2)
   expect_equal(out[local_id == 1L, final_logmean], -1.5)
 
-  # Station 2 ships ground truth, so both take their zero-error values.
+  # Station 2 ships ground truth, so both take their zero-error values: a bound of 0 and
+  # log(0) expected error. -Inf rather than a finite floor because the LightGBM prediction
+  # is unconstrained, and a model candidate that undercut the floor would outrank the
+  # ground truth in make_panel_ids().
   expect_equal(out[local_id == 2L, final_long], -61.5)
   expect_equal(out[local_id == 2L, conf_dist_km], 0)
-  expect_equal(out[local_id == 2L, final_logmean], log(GBM_LOG_OFFSET))
-
-  # No model prediction can undercut the ground-truth value.
-  expect_lt(out[local_id == 2L, final_logmean], min(model_predictions$pred_logmean))
+  expect_equal(out[local_id == 2L, final_logmean], -Inf)
 })
 
 test_that("finalize_coords keeps final_logmean out of the published schema", {

--- a/tests/testthat/test-finalize_coords.R
+++ b/tests/testthat/test-finalize_coords.R
@@ -1,0 +1,75 @@
+## Spec test for finalize_coords() (R/data_cleaning.R), covering the two columns that
+## describe the shipped coordinate's accuracy: conf_dist_km (published upper bound) and
+## final_logmean (expected error on the model's log scale, internal, and what
+## make_panel_ids() ranks a panel's station-years on).
+
+test_that("finalize_coords carries the winner's expected error and zeroes it for TSE rows", {
+  locais <- data.table::data.table(
+    local_id = c(1L, 2L),
+    ano = c(2018L, 2022L),
+    normalized_name = c("a", "b"),
+    normalized_addr = c("a", "b"),
+    normalized_st = c("a", "b"),
+    normalized_bairro = c("a", "b")
+  )
+  model_predictions <- data.table::data.table(
+    local_id = c(1L, 1L, 2L),
+    long = c(-60, -60.5, -61),
+    lat = c(-9, -9.5, -8),
+    conf_dist_km = c(1.2, 0.3, 2.0),
+    # Station 1's first candidate wins on expected error despite the wider bound.
+    pred_logmean = c(-1.5, -0.2, 0.4)
+  )
+  # Only station 2 has field-collected TSE coordinates.
+  tsegeocoded_locais <- data.table::data.table(
+    local_id = 2L,
+    tse_long = -61.5,
+    tse_lat = -8.5
+  )
+
+  out <- finalize_coords(
+    copy(locais),
+    copy(model_predictions),
+    copy(tsegeocoded_locais)
+  )
+
+  # Station 1 ships the model's pick, so both accuracy columns are the winner's own.
+  expect_equal(out[local_id == 1L, final_long], -60)
+  expect_equal(out[local_id == 1L, conf_dist_km], 1.2)
+  expect_equal(out[local_id == 1L, final_logmean], -1.5)
+
+  # Station 2 ships ground truth, so both take their zero-error values.
+  expect_equal(out[local_id == 2L, final_long], -61.5)
+  expect_equal(out[local_id == 2L, conf_dist_km], 0)
+  expect_equal(out[local_id == 2L, final_logmean], log(GBM_LOG_OFFSET))
+
+  # No model prediction can undercut the ground-truth value.
+  expect_lt(out[local_id == 2L, final_logmean], min(model_predictions$pred_logmean))
+})
+
+test_that("finalize_coords keeps final_logmean out of the published schema", {
+  geocoded <- data.table::data.table(
+    local_id = 1L,
+    ano = 2018L,
+    sg_uf = "AC",
+    cd_localidade_tse = 1L,
+    cod_localidade_ibge = 1200013L,
+    nr_zona = 1L,
+    nr_locvot = 1L,
+    nr_cep = "69900000",
+    nm_localidade = "x",
+    nm_locvot = "x",
+    ds_endereco = "x",
+    ds_bairro = "x",
+    pred_long = -60,
+    pred_lat = -9,
+    conf_dist_km = 0.5,
+    final_logmean = -1.5,
+    tse_long = NA_real_,
+    tse_lat = NA_real_,
+    final_long = -60,
+    final_lat = -9
+  )
+
+  expect_false("final_logmean" %in% names(to_geocoded_export_schema(geocoded)))
+})

--- a/tests/testthat/test-make_panel_ids.R
+++ b/tests/testthat/test-make_panel_ids.R
@@ -65,8 +65,9 @@ test_that("make_panel_ids ranks on expected error, not the published bound", {
 })
 
 test_that("make_panel_ids keeps TSE ground truth ahead of any model coordinate", {
-  # finalize_coords() gives a TSE-covered station-year the zero-error value of
-  # final_logmean, which no model prediction can undercut.
+  # finalize_coords() gives a TSE-covered station-year final_logmean = -Inf. The model
+  # prediction here is absurdly optimistic (log-km far below anything LightGBM produces)
+  # precisely to show the precedence does not rest on the model's range.
   panel_ids_combined <- data.table::data.table(
     local_id = c("t1", "t2"),
     panel_id = c("pt", "pt")
@@ -77,7 +78,7 @@ test_that("make_panel_ids keeps TSE ground truth ahead of any model coordinate",
     final_long = c(-30, -31),
     final_lat = c(-5, -6),
     conf_dist_km = c(0, 0.3),
-    final_logmean = c(log(GBM_LOG_OFFSET), log(0.05))
+    final_logmean = c(-Inf, -50)
   )
 
   out <- make_panel_ids(copy(panel_ids_combined), copy(geocoded_locais))

--- a/tests/testthat/test-make_panel_ids.R
+++ b/tests/testthat/test-make_panel_ids.R
@@ -1,11 +1,11 @@
 ## Spec tests for make_panel_ids() (R/panel_creation.R).
 ## Joins the final coordinate (TSE-when-available, otherwise the model's
 ## selection) from geocoded_locais onto the combined panel-id table,
-## and assigns every station in a panel the single most accurate coordinate the
-## panel offers: smallest conf_dist_km, ties broken toward the most recent year.
-## Assertions are keyed on local_id, not row order.
+## and assigns every station in a panel the single best coordinate the panel
+## offers: lowest expected error (final_logmean), ties broken toward the most
+## recent year. Assertions are keyed on local_id, not row order.
 
-test_that("make_panel_ids picks each panel's smallest-conf_dist_km coordinate", {
+test_that("make_panel_ids picks each panel's lowest-expected-error coordinate", {
   panel_ids_combined <- data.table::data.table(
     local_id = c("l1", "l2", "l3"),
     panel_id = c("p1", "p1", "p2")
@@ -15,8 +15,9 @@ test_that("make_panel_ids picks each panel's smallest-conf_dist_km coordinate", 
     ano = c(2018L, 2022L, 2020L),
     final_long = c(-60, -61, -62),
     final_lat = c(-9, -8, -7),
-    # l1 is more accurate (smaller conf_dist_km) than the more recent l2.
-    conf_dist_km = c(0.2, 0.5, 3.0)
+    conf_dist_km = c(0.2, 0.5, 3.0),
+    # l1 is expected to be more accurate than the more recent l2.
+    final_logmean = c(-2.0, -1.0, 0.5)
   )
 
   out <- make_panel_ids(copy(panel_ids_combined), copy(geocoded_locais))
@@ -24,9 +25,9 @@ test_that("make_panel_ids picks each panel's smallest-conf_dist_km coordinate", 
   expect_equal(nrow(out), 3L)
   expect_true(all(c("local_id", "panel_id", "long", "lat", "conf_dist_km") %in% names(out)))
 
-  # Panel p1 spans 2018 (l1, conf_dist_km 0.2) and 2022 (l2, conf_dist_km 0.5). The
-  # coordinate is chosen by accuracy, not recency, so both stations take l1's
-  # 2018 coordinate - NOT l2's more recent one.
+  # Panel p1 spans 2018 (l1) and 2022 (l2). The coordinate is chosen by expected
+  # accuracy, not recency, so both stations take l1's 2018 coordinate, and the
+  # published bound that ships is l1's.
   expect_equal(out[local_id == "l1", long], -60)
   expect_equal(out[local_id == "l1", lat], -9)
   expect_equal(out[local_id == "l2", long], -60)
@@ -36,6 +37,53 @@ test_that("make_panel_ids picks each panel's smallest-conf_dist_km coordinate", 
   expect_equal(out[local_id == "l3", long], -62)
   expect_equal(out[local_id == "l3", lat], -7)
   expect_equal(out[local_id == "l3", conf_dist_km], 3.0)
+})
+
+test_that("make_panel_ids ranks on expected error, not the published bound", {
+  # Issue #142's inversion: the 2018 coordinate is expected to be far more accurate
+  # but carries the wider calibrated bound (its features sit in a sparse region).
+  # Ranking on the bound would ship the 2022 coordinate to the whole panel.
+  panel_ids_combined <- data.table::data.table(
+    local_id = c("w1", "w2"),
+    panel_id = c("pw", "pw")
+  )
+  geocoded_locais <- data.table::data.table(
+    local_id = c("w1", "w2"),
+    ano = c(2018L, 2022L),
+    final_long = c(-40, -41),
+    final_lat = c(-20, -21),
+    conf_dist_km = c(4.0, 0.9),
+    final_logmean = c(log(0.08), log(0.9))
+  )
+
+  out <- make_panel_ids(copy(panel_ids_combined), copy(geocoded_locais))
+
+  expect_equal(out[local_id == "w2", long], -40)
+  expect_equal(out[local_id == "w2", lat], -20)
+  # The winner's own bound ships with it.
+  expect_equal(out[local_id == "w2", conf_dist_km], 4.0)
+})
+
+test_that("make_panel_ids keeps TSE ground truth ahead of any model coordinate", {
+  # finalize_coords() gives a TSE-covered station-year the zero-error value of
+  # final_logmean, which no model prediction can undercut.
+  panel_ids_combined <- data.table::data.table(
+    local_id = c("t1", "t2"),
+    panel_id = c("pt", "pt")
+  )
+  geocoded_locais <- data.table::data.table(
+    local_id = c("t1", "t2"),
+    ano = c(2018L, 2022L),
+    final_long = c(-30, -31),
+    final_lat = c(-5, -6),
+    conf_dist_km = c(0, 0.3),
+    final_logmean = c(log(GBM_LOG_OFFSET), log(0.05))
+  )
+
+  out <- make_panel_ids(copy(panel_ids_combined), copy(geocoded_locais))
+
+  expect_equal(out[local_id == "t2", long], -30)
+  expect_equal(out[local_id == "t2", conf_dist_km], 0)
 })
 
 test_that("make_panel_ids uses model coordinates when a panel has no TSE year", {
@@ -51,12 +99,13 @@ test_that("make_panel_ids uses model coordinates when a panel has no TSE year", 
     ano = c(2006L, 2008L),
     final_long = c(-50, -51),
     final_lat = c(-10, -11),
-    conf_dist_km = c(1.5, 0.8)
+    conf_dist_km = c(1.5, 0.8),
+    final_logmean = c(0.4, -0.3)
   )
 
   out <- make_panel_ids(copy(panel_ids_combined), copy(geocoded_locais))
 
-  # Best (smallest conf_dist_km) is a2; both stations take it. No NA coordinates.
+  # Best expected error is a2; both stations take it. No NA coordinates.
   expect_equal(sum(is.na(out$long)), 0L)
   expect_equal(out[local_id == "a1", long], -51)
   expect_equal(out[local_id == "a2", lat], -11)
@@ -73,11 +122,32 @@ test_that("make_panel_ids leaves a panel uncoordinated only when every year is u
     ano = c(2010L, 2012L),
     final_long = c(NA_real_, NA_real_),
     final_lat = c(NA_real_, NA_real_),
-    conf_dist_km = c(NA_real_, NA_real_)
+    conf_dist_km = c(NA_real_, NA_real_),
+    final_logmean = c(NA_real_, NA_real_)
   )
 
   out <- make_panel_ids(copy(panel_ids_combined), copy(geocoded_locais))
 
   expect_true(all(is.na(out$long)))
   expect_true(all(is.na(out$lat)))
+})
+
+test_that("make_panel_ids stops when a geocoded station-year carries no expected error", {
+  panel_ids_combined <- data.table::data.table(
+    local_id = "s1",
+    panel_id = "ps"
+  )
+  geocoded_locais <- data.table::data.table(
+    local_id = "s1",
+    ano = 2018L,
+    final_long = -45,
+    final_lat = -12,
+    conf_dist_km = 0.4,
+    final_logmean = NA_real_
+  )
+
+  expect_error(
+    make_panel_ids(copy(panel_ids_combined), copy(geocoded_locais)),
+    "expected error"
+  )
 })


### PR DESCRIPTION
## What this is for

Each polling station in the dataset is tracked across elections as a "panel," and the panel publishes a **single** coordinate that all of its election-years share. So the panel has to choose which year's coordinate the rest inherit. It was choosing the year with the smallest published error bound.

That is the wrong quantity. The bound is a calibrated *upper* limit on a coordinate's error, so ranking on it prefers a coordinate whose error is **predictable** over one whose error is **small** — the same inversion #140 found when the pipeline was picking each station's own coordinate that way. Panels now choose the year whose error is expected to be smallest, which is how each station's own coordinate has been picked since #143.

Closes #142.

## What changed

**Selection.** `make_panel_ids()` ranks a panel's station-years on `final_logmean` (the selection model's expected error for the coordinate that shipped) instead of `conf_dist_km`. Ties still break toward the most recent year.

**Threading.** `pred_logmean` was not reaching `make_panel_ids()` — `finalize_coords()` dropped it. It now rides along as `final_logmean`, an internal column. The published schemas do not change: `to_geocoded_export_schema()` drops it, and `panel_ids.csv.gz` keeps `panel_id, local_id, long, lat, conf_dist_km`. The bound that ships with a panel is now the *selected* year's, which is not necessarily the panel's smallest — the README says so.

**Ground truth still wins.** A TSE-covered year has zero error, so its `final_logmean` is `log(0)` = `-Inf`, alongside its `conf_dist_km = 0`. The infinity is deliberate rather than cosmetic: review caught that a finite floor (`log(GBM_LOG_OFFSET)`) would make ground-truth precedence depend on no LightGBM prediction ever falling below it, which nothing enforces.

**Schema constant renamed.** Release Gate 2 asserts set equality on the *internal* `geocoded_locais` schema, so the new column has to be declared there. `RELEASE_EXPORT_COLS` was never the published header — Gate 9 checks that against `GEOCODED_EXPORT_SCHEMA` — so it is now `GEOCODED_TABLE_COLS`.

## The measurement

Panel coordinate quality is a different question from the station-level headline metric, and it needed its own answer. `compute_panel_coord_accuracy()` runs **both** ranking rules over the same panels and scores each rule's panel coordinate against **every covered member's** TSE coordinate.

It scores out-of-fold model coordinates with **no TSE substitution**, deliberately. In production, a panel holding any TSE-covered year ships that year's ground truth under either rule — so the rules can only diverge on panels with no covered year, which are exactly the panels with no truth to measure against. Withholding the substitution lets the covered panels stand in for the uncovered ones. It is the same extrapolation the evaluation spec already makes for stations, one level up.

The table also reports the share of station-years whose coordinate actually changes, because every station-year where the rules agree dilutes the metric deltas toward zero.

Dev-mode (AC/RR) results, 3,687 station-years across 1,061 panels:

| | Bound | Expected error |
|---|---|---|
| Median error | 0.0260 km | 0.0258 km |
| Within 500 m | 82.4% | **82.8%** |
| Within 500 m, rural | 71.3% | **72.5%** |

The two rules disagree on 6.3% of station-years, which is what the overall deltas are diluted by. A national run is what the real numbers come from.

## Verification

- Dev-mode (AC/RR) rebuild green through the release gates, exports, and the rendered report.
- 357 unit tests pass. New spec tests cover the threading (`test-finalize_coords.R`), the ranking including the issue's inversion scenario and ground-truth precedence, and the new measurement.
- Reviewed at the full tier: a Codex pass caught the finite-floor precedence hole, and a diff review caught a missing one-panel-per-station assertion in the measurement. Both fixed in their own commits.

Docs: README (panel `long`/`lat`/`conf_dist_km`), evaluation spec §7c, and a report section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)