### PR TITLE
Rank string matches on Jaro-Winkler alone, not divided by string length

### DIFF
--- a/R/evaluation.R
+++ b/R/evaluation.R
@@ -233,9 +233,8 @@ select_oof_candidates <- function(oof_predictions) {
 
 # The trivial deterministic selector the model has to beat: per covered station, the
 # highest-precedence candidate available, ties within a rank broken on the smallest
-# string distance. mindist is on incomparable scales across ranks (length-normalized
-# Jaro-Winkler for most sources, unnormalized for bairro, over different fields, absent
-# for geocodebr), so it can only break ties inside one.
+# string distance. mindist is not comparable across ranks -- it is Jaro-Winkler over
+# different fields, and absent for geocodebr -- so it can only break ties inside one.
 select_baseline_candidates <- function(model_data) {
   # Precedence, most specific reference first: references that locate the building, then
   # the address, then the aggregates that only stand in for it. Census vintages of the

--- a/R/string_matching.R
+++ b/R/string_matching.R
@@ -6,10 +6,8 @@ library(stringdist)
 
 # Nearest target string for each query, by Jaro-Winkler distance, considering only targets
 # that share at least one whitespace-delimited word with the query. A query with no such
-# target gets min_dist = Inf and an NA match. normalize_by_length divides the distance by
-# the longer of the two strings, which favours longer targets; neighbourhood matching turns
-# it off. Ties go to the lowest target index.
-match_strings <- function(query_strings, target_strings, normalize_by_length = TRUE) {
+# target gets min_dist = Inf and an NA match. Ties go to the lowest target index.
+match_strings <- function(query_strings, target_strings) {
   # An inverted word -> target index makes each query's candidate set a lookup, so no
   # query x target matrix is ever built.
   target_words <- strsplit(tolower(target_strings), "\\s+")
@@ -17,7 +15,6 @@ match_strings <- function(query_strings, target_strings, normalize_by_length = T
     rep.int(seq_along(target_words), lengths(target_words)),
     unlist(target_words, use.names = FALSE)
   )
-  target_nchar <- nchar(target_strings)
 
   # A municipality's rows are station-years, so the same address recurs across elections
   # (roughly 6 times nationally). Matching is pure, so each distinct query is matched once
@@ -40,10 +37,6 @@ match_strings <- function(query_strings, target_strings, normalize_by_length = T
     }
 
     dists <- stringdist::stringdist(queries[i], target_strings[candidates], method = "jw")
-    if (normalize_by_length) {
-      dists <- dists / pmax(nchar(queries[i]), target_nchar[candidates])
-    }
-
     best <- which.min(dists)
     min_dist[i] <- dists[best]
     best_index[i] <- candidates[best]
@@ -158,17 +151,16 @@ match_stbairro_muni <- function(locais_muni, st_muni, bairro_muni) {
   # Match on neighborhood
   bairro_results <- match_strings(
     locais_muni$normalized_bairro,
-    bairro_muni$norm_bairro,
-    normalize_by_length = FALSE # Don't normalize for neighborhoods
+    bairro_muni$norm_bairro
   )
 
   st_idx <- st_results$best_index
   bairro_idx <- bairro_results$best_index
 
   # These two references are coordinate medians over a whole street or neighborhood, so each
-  # knows exactly one field; the other three similarities are NA. sim_bairro_bairro repeats
-  # mindist_bairro, the one match run unnormalized, so the two are the same number.
-  # The NA columns are still emitted -- melt_match_candidates() explains why.
+  # knows exactly one field; the other three similarities are NA. The one similarity each does
+  # carry repeats its own mindist, since both are now plain Jaro-Winkler on the field the match
+  # was made on. The NA columns are still emitted -- melt_match_candidates() explains why.
   data.table(
     local_id = locais_muni$local_id,
     match_st = st_results$best_match,

--- a/docs/specs/2026-07-evaluation-spec.md
+++ b/docs/specs/2026-07-evaluation-spec.md
@@ -250,11 +250,10 @@ same reference share a rank — they are the same kind of reference differing on
 so `mindist` decides between them rather than an invented vintage preference.
 
 **Why the tie-break stays inside a rank.** `mindist` is not comparable across ranks — it
-is length-normalized Jaro-Winkler for most sources, unnormalized for `bairro`, computed
-over different fields (name / street / neighborhood / address line), and absent for
-`geocodebr`. Within a rank it *is* like-for-like (same matcher, same field, same
-normalization). A cross-rank `argmin` would put different scales against each other, so
-the "smallest `mindist` wins" variant from the assessment is not implemented.
+is Jaro-Winkler computed over different fields (name / street / neighborhood / address
+line), and absent for `geocodebr`. A 0.2 name distance and a 0.2 street distance are not
+the same evidence. Within a rank it *is* like-for-like (same matcher, same field), so the
+"smallest `mindist` wins" variant from the assessment is not implemented.
 
 The rank table is the baseline's entire definition, so it is exhaustive over the candidate
 types the modeling table emits and the selector **errors** on an unranked type: a new

--- a/scripts/compare_methodology_snapshots.R
+++ b/scripts/compare_methodology_snapshots.R
@@ -32,6 +32,14 @@ read_snapshot <- function(label) {
 base <- read_snapshot(args[1])
 cand <- read_snapshot(args[2])
 
+# Every delta below is a difference between two runs over the same stations. A dev-mode
+# snapshot against a production one merges cleanly on stratum:level and prints deltas that
+# are differences between populations, not methodologies.
+universe <- function(snap) as.data.table(snap$accuracy_tables)[stratum == "overall", n_total]
+stopifnot(
+  "the two snapshots cover different station universes" = universe(base) == universe(cand)
+)
+
 cat(sprintf(
   "baseline  %s (built_from %s, taken %s)\ncandidate %s (built_from %s, taken %s)\n",
   base$label,
@@ -76,7 +84,8 @@ cat("delta_within_500m is model minus trivial selector within each run.\n\n")
 bc <- merge(
   as.data.table(base$baseline_comparison)[, .(stratum, level, base_run = delta_within_500m)],
   as.data.table(cand$baseline_comparison)[, .(stratum, level, cand_run = delta_within_500m)],
-  by = c("stratum", "level")
+  by = c("stratum", "level"),
+  all = TRUE
 )
 bc[, shift := cand_run - base_run]
 print(bc[stratum %in% c("overall", "urban_rural", "region")], digits = 3)

--- a/scripts/compare_methodology_snapshots.R
+++ b/scripts/compare_methodology_snapshots.R
@@ -1,0 +1,97 @@
+## Compare two methodology snapshots written by scripts/snapshot_methodology_baseline.R.
+##
+##   Rscript scripts/compare_methodology_snapshots.R <baseline_label> <candidate_label>
+##
+## Reads output/methodology_snapshot_<label>.rds for each. Prints the accuracy deltas the
+## evaluation spec gates on, the model-free baseline_comparison control, and the shift in
+## which source gets selected.
+##
+## Deltas are candidate minus baseline: within_500m up is better, median/p90/p95 down is
+## better. The national within-500m figure is not the gate -- urban stations are two thirds
+## of the universe, so it can sit flat while rural moves a point. Read the rural row and the
+## p90/p95 tail. Selected-source churn is expected whenever the matcher changes, because
+## mindist is a trained feature and the model re-learns on the new scale; churn on its own
+## is not evidence either way.
+
+suppressMessages(library(data.table))
+options(width = 150)
+
+args <- commandArgs(trailingOnly = TRUE)
+if (length(args) != 2L) {
+  stop("Usage: Rscript scripts/compare_methodology_snapshots.R <baseline_label> <candidate_label>")
+}
+
+read_snapshot <- function(label) {
+  path <- file.path("output", sprintf("methodology_snapshot_%s.rds", label))
+  if (!file.exists(path)) {
+    stop("no snapshot at ", path)
+  }
+  readRDS(path)
+}
+
+base <- read_snapshot(args[1])
+cand <- read_snapshot(args[2])
+
+cat(sprintf(
+  "baseline  %s (built_from %s, taken %s)\ncandidate %s (built_from %s, taken %s)\n",
+  base$label,
+  base$built_from,
+  format(base$taken_at),
+  cand$label,
+  cand$built_from,
+  format(cand$taken_at)
+))
+
+METRICS <- c("match_rate", "median_km", "p90", "p95", "within_500m")
+
+# Accuracy deltas on the strata the spec gates on. The match_source cut is excluded: its
+# levels hold different stations under each run, so a per-level delta is not like-for-like.
+delta_table <- function(a, b, metrics) {
+  a <- as.data.table(a)[stratum != "match_source"]
+  b <- as.data.table(b)[stratum != "match_source"]
+  m <- merge(
+    a[, c("stratum", "level", "n_total", metrics), with = FALSE],
+    b[, c("stratum", "level", metrics), with = FALSE],
+    by = c("stratum", "level"),
+    suffixes = c("_base", "_cand"),
+    all = TRUE
+  )
+  for (v in metrics) {
+    m[, (paste0("d_", v)) := get(paste0(v, "_cand")) - get(paste0(v, "_base"))]
+  }
+  m[, c("stratum", "level", "n_total", paste0("d_", metrics)), with = FALSE]
+}
+
+acc <- delta_table(base$accuracy_tables, cand$accuracy_tables, METRICS)
+
+cat("\n== accuracy delta (candidate - baseline) ==\n")
+cat("within_500m up is better; median_km / p90 / p95 down is better.\n\n")
+print(acc[stratum %in% c("overall", "urban_rural", "region", "urban_rural:region")], digits = 3)
+
+# The model-free control: how each run's selector compares to the trivial precedence
+# baseline it shares. Immune to retrain churn, so it separates a real ranking improvement
+# from the model landing somewhere different.
+cat("\n== model-vs-trivial-baseline gap, both runs ==\n")
+cat("delta_within_500m is model minus trivial selector within each run.\n\n")
+bc <- merge(
+  as.data.table(base$baseline_comparison)[, .(stratum, level, base_run = delta_within_500m)],
+  as.data.table(cand$baseline_comparison)[, .(stratum, level, cand_run = delta_within_500m)],
+  by = c("stratum", "level")
+)
+bc[, shift := cand_run - base_run]
+print(bc[stratum %in% c("overall", "urban_rural", "region")], digits = 3)
+
+# Which source the model picks, and how accurate each pick is. Expect movement here.
+cat("\n== selected match source ==\n")
+source_share <- function(snap) {
+  d <- as.data.table(snap$oof_selected_matches)[geocoded == TRUE]
+  d[, .(share = 100 * .N / nrow(d), within_500m = 100 * mean(error_km <= 0.5)), by = match_source]
+}
+ms <- merge(
+  source_share(base)[, .(match_source, share_base = share, w500_base = within_500m)],
+  source_share(cand)[, .(match_source, share_cand = share, w500_cand = within_500m)],
+  by = "match_source",
+  all = TRUE
+)
+ms[, d_share := share_cand - share_base]
+print(ms[order(-share_cand)], digits = 3)

--- a/scripts/compare_methodology_snapshots.R
+++ b/scripts/compare_methodology_snapshots.R
@@ -3,7 +3,7 @@
 ##   Rscript scripts/compare_methodology_snapshots.R <baseline_label> <candidate_label>
 ##
 ## Reads output/methodology_snapshot_<label>.rds for each. Prints the accuracy deltas the
-## evaluation spec gates on, the model-free baseline_comparison control, and the shift in
+## evaluation spec gates on, the trivial precedence selector beside them, and the shift in
 ## which source gets selected.
 ##
 ## Deltas are candidate minus baseline: within_500m up is better, median/p90/p95 down is
@@ -76,19 +76,31 @@ cat("\n== accuracy delta (candidate - baseline) ==\n")
 cat("within_500m up is better; median_km / p90 / p95 down is better.\n\n")
 print(acc[stratum %in% c("overall", "urban_rural", "region", "urban_rural:region")], digits = 3)
 
-# The model-free control: how each run's selector compares to the trivial precedence
-# baseline it shares. Immune to retrain churn, so it separates a real ranking improvement
-# from the model landing somewhere different.
-cat("\n== model-vs-trivial-baseline gap, both runs ==\n")
-cat("delta_within_500m is model minus trivial selector within each run.\n\n")
-bc <- merge(
-  as.data.table(base$baseline_comparison)[, .(stratum, level, base_run = delta_within_500m)],
-  as.data.table(cand$baseline_comparison)[, .(stratum, level, cand_run = delta_within_500m)],
-  by = c("stratum", "level"),
-  all = TRUE
+# The trivial precedence selector, which trains on nothing. Read it in absolute terms:
+# it breaks ties within a rank on mindist, so a change to the matcher moves it too, and
+# it is model-free but not matcher-free. The model-minus-trivial gap is therefore not a
+# control -- a matcher that improves raw ranking lifts the trivial selector most, and the
+# gap narrows while both selectors get better. What the trivial column does isolate is
+# match quality with no learned compensation on top.
+cat("\n== trivial precedence selector, within_500m ==\n")
+cat("d_trivial is the matcher's effect with nothing learned on top; d_model is beside it.\n\n")
+bc_cols <- function(snap) {
+  as.data.table(snap$baseline_comparison)[, .(
+    stratum,
+    level,
+    trivial = within_500m_baseline,
+    model = within_500m_model
+  )]
+}
+bc <- merge(bc_cols(base), bc_cols(cand), by = c("stratum", "level"), suffixes = c("_base", "_cand"), all = TRUE)
+bc[, `:=`(d_trivial = trivial_cand - trivial_base, d_model = model_cand - model_base)]
+print(
+  bc[
+    stratum %in% c("overall", "urban_rural", "region"),
+    .(stratum, level, trivial_base, trivial_cand, d_trivial, d_model)
+  ],
+  digits = 3
 )
-bc[, shift := cand_run - base_run]
-print(bc[stratum %in% c("overall", "urban_rural", "region")], digits = 3)
 
 # Which source the model picks, and how accurate each pick is. Expect movement here.
 cat("\n== selected match source ==\n")

--- a/scripts/compare_methodology_snapshots.R
+++ b/scripts/compare_methodology_snapshots.R
@@ -93,5 +93,9 @@ ms <- merge(
   by = "match_source",
   all = TRUE
 )
+# A source absent from one run was picked zero times there -- an observed zero, so the
+# share it gained or lost is reportable. Its accuracy stays NA: no picks, nothing to score.
+ms[is.na(share_base), share_base := 0]
+ms[is.na(share_cand), share_cand := 0]
 ms[, d_share := share_cand - share_base]
 print(ms[order(-share_cand)], digits = 3)

--- a/tests/testthat/test-match_strings.R
+++ b/tests/testthat/test-match_strings.R
@@ -1,7 +1,7 @@
 ## Spec tests for match_strings() (R/string_matching.R).
-## For each query string it returns the nearest target (Jaro-Winkler, length-normalized
-## by default), but only among targets that share at least one whitespace-delimited
-## word with the query. A query sharing no word with any target gets no candidate:
+## For each query string it returns the nearest target (Jaro-Winkler), but only among
+## targets that share at least one whitespace-delimited word with the query. A query
+## sharing no word with any target gets no candidate:
 ## min_dist stays Inf and best_match/best_index are NA. Returns a list of three
 ## parallel vectors: min_dist, best_match, best_index.
 
@@ -34,6 +34,21 @@ test_that("match_strings returns NA/Inf when no target shares a word", {
   expect_true(is.na(res$best_match[2]))
   expect_true(is.na(res$best_index[2]))
   expect_true(is.infinite(res$min_dist[2]))
+})
+
+test_that("match_strings ranks by similarity alone, not string length", {
+  # Jaro-Winkler is already normalized to 0-1, so candidate length must not enter the
+  # ranking. Here the sprawling name is the worse match (JW 0.43 vs 0.30), but dividing
+  # by max(nchar) made its extra 64 characters win the comparison.
+  res <- match_strings(
+    query_strings = "jose joaquim",
+    target_strings = c(
+      "escola estadual indigena jose joaquim de sousa filho da comunidade raposa serra do sol",
+      "indigena jose joaquim"
+    )
+  )
+  expect_equal(res$best_index, 2L)
+  expect_equal(res$min_dist, stringdist::stringdist("jose joaquim", "indigena jose joaquim", method = "jw"))
 })
 
 test_that("match_strings is case-insensitive when gating candidates", {


### PR DESCRIPTION
## What this is for

When the pipeline looks for the reference record that matches a polling station, it scores
every candidate on how similar the two names are and keeps the closest. The scoring step had
a bug: after computing the similarity it divided the result by the length of the longer name.
Jaro-Winkler already returns a number between 0 and 1 whatever the lengths are, so that
division didn't correct for anything — it just made long names look closer than short ones.
Since polling stations have short names and official school records have long ones, a long
wrong record could beat a short right one.

This removes the division. Nothing else about the matching changes, which is the point: #45
removed this *and* the candidate prefilter at the same time, so neither effect could be
measured on its own. Fixes #150.

## Result of the production run

Measured against a frozen master baseline (`methodology_snapshot_master_20260812`, built from
4b4322d and byte-identical to `v015`, so the two selectors are being compared on the same
station universe with no run-to-run noise in between).

| stratum | within 500 m | median | p90 | p95 |
|---|---|---|---|---|
| overall | **+0.60 pp** (81.89 → 82.48) | −1.4 m | −249 m | −582 m |
| **rural** | **+1.02 pp** | −11.3 m | −854 m | −1.04 km |
| urban | +0.40 pp | −1.0 m | −26 m | −87 m |

Every region improves (+0.44 to +0.74 pp). The p90/p95 tail improves in nearly every cell.
The gate from #45 was the rural margin and the error tail, and both move the right way — this
is the opposite of the #45 run, where rural regressed 0.81 pp and its p90 grew 1.86 km.

The handful of negative cells are all tiny: `NA:Centro-Oeste` is 84 stations (−3.57 pp is
three of them), `NA:Norte` is 90, and `rural:Centro-Oeste` moves −0.04 pp on 2,632.

## One thing that reads as a regression and isn't

The gap between the model and the trivial precedence selector *narrows* by 3.8 pp overall.
That happens because both selectors got better and the trivial one got better faster:

| stratum | trivial selector | model |
|---|---|---|
| overall | 57.32 → 61.76 (**+4.44**) | +0.60 |
| rural | 40.24 → 42.15 (**+1.90**) | +1.02 |
| urban | 64.95 → 70.51 (**+5.56**) | +0.40 |

#45 suggested reading that gap as a control immune to retrain churn. It isn't: the trivial
selector breaks ties within a precedence rank on `mindist`, so it is model-free but not
matcher-free, and a matcher change moves it too. The last commit here rewrites that section of
the comparison script to print both selectors' absolute accuracy instead of their gap, so the
next methodology change doesn't get misread the same way.

The reading that fits: fixing the ranking helps most where nothing is layered on top of it.
The model had partly learned to work around the bad ranking through its other features, so it
banks less of the gain — but it still gains, everywhere that matters.

## Also in here

- `scripts/compare_methodology_snapshots.R`, new — diffs two frozen snapshots on the gated
  strata. It refuses to compare snapshots taken over different station universes, so a
  dev-mode snapshot can't be silently diffed against a production one.
- A regression test for the ranking. Note the example in #150 doesn't work as a test: its two
  strings share no word with the query, so the candidate gate excludes the long one before
  ranking ever happens. The test uses a pair that actually flips.

## Checks

- Unit suite passes (359).
- Dev-mode (AC/RR) pipeline builds clean; release gates pass.
- Reviewed at full tier: Codex layer (1 finding) plus `/code-review high --fix` (2 findings),
  all fixed in the commits here. I traced every `mindist` consumer for scale sensitivity —
  no thresholds anywhere, the within-rank tie-break stays commensurable, the LightGBM recipe
  has no correlation-filter step. The distance quartiles in
  `output/string_match_diagnostics.txt` will jump about an order of magnitude; that's the new
  scale showing up in a report, not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
