### PR TITLE
Rank string matches on trigram overlap, not Jaro-Winkler

### DIFF
--- a/R/data_cleaning.R
+++ b/R/data_cleaning.R
@@ -464,6 +464,14 @@ make_tract_centroids <- function(tracts) {
   return(tracts)
 }
 
+# A field every one of whose tokens was stripped is missing, not empty. The string
+# distances compare character trigrams, and two empty strings share a trigram set, so ""
+# would score as a perfect match between any two fields that normalized away to nothing.
+blank_to_na <- function(x) {
+  x[!nzchar(x)] <- NA_character_
+  x
+}
+
 # Normalizes an address string for cross-dataset matching.
 normalize_address <- function(x) {
   # normalize_name() squishes whitespace first, so the single-space patterns below
@@ -477,7 +485,7 @@ normalize_address <- function(x) {
   result <- str_replace_all(result, "^r\\b", "rua")
   result <- str_replace_all(result, "\\bs n\\b", "sn")
   # Squish again: the descriptor removals leave a doubled space behind.
-  str_squish(result)
+  blank_to_na(str_squish(result))
 }
 
 ## Generic school terms stripped by normalize_school() and used as a school-detection feature
@@ -543,7 +551,7 @@ normalize_name <- function(x) {
   result <- stringi::stri_trans_general(x, "Latin-ASCII")
   result <- str_to_lower(result)
   result <- str_remove_all(result, "[[:punct:]]")
-  str_squish(result)
+  blank_to_na(str_squish(result))
 }
 
 # normalize_name() plus removal of the generic school terms, so two records for the same
@@ -551,7 +559,7 @@ normalize_name <- function(x) {
 SCHOOL_SYNONYM_PATTERN <- paste0("\\b", school_synonyms, "\\b", collapse = "|")
 
 normalize_school <- function(x) {
-  str_squish(str_remove_all(normalize_name(x), SCHOOL_SYNONYM_PATTERN))
+  blank_to_na(str_squish(str_remove_all(normalize_name(x), SCHOOL_SYNONYM_PATTERN)))
 }
 
 # Cleans the INEP school census and normalizes its school names and addresses.
@@ -600,12 +608,12 @@ calc_muni_area <- function(muni_shp) {
   muni_shp[, .(cod_localidade_ibge = code_muni, area)]
 }
 
-# School rows of a cleaned CNEFE table (either year). An empty norm_desc has no name
+# School rows of a cleaned CNEFE table (either year). A missing norm_desc has no name
 # to match on, so those rows are dropped.
 get_cnefe_schools <- function(cnefe) {
   schools <- cnefe[especie_lab == "estabelecimento de ensino"]
   schools[, norm_desc := normalize_school(desc)]
-  schools[norm_desc != ""]
+  schools[!is.na(norm_desc)]
 }
 
 convert_coords_dms <- function(coord_strings) {

--- a/R/string_match_diagnostics.R
+++ b/R/string_match_diagnostics.R
@@ -20,6 +20,8 @@ string_match_coord_cols <- function(match_name) {
 }
 
 # NA-coordinate, no-match, perfect-match and distance-quartile metrics for one match table.
+# "Perfect" is distance 0, which under a trigram distance means the two strings have the
+# same set of trigrams -- string equality in every practical case, but not by definition.
 calculate_string_match_diagnostics <- function(match_data, match_name, long_col, lat_col) {
   missing_cols <- setdiff(c(long_col, lat_col), names(match_data))
   if (length(missing_cols) > 0) {

--- a/R/string_matching.R
+++ b/R/string_matching.R
@@ -4,9 +4,16 @@ library(data.table)
 library(stringr)
 library(stringdist)
 
-# Nearest target string for each query, by Jaro-Winkler distance, considering only targets
-# that share at least one whitespace-delimited word with the query. A query with no such
-# target gets min_dist = Inf and an NA match. Ties go to the lowest target index.
+# Nearest target string for each query, by Jaccard distance over character trigrams,
+# considering only targets that share at least one whitespace-delimited word with the
+# query. A query with no such target gets min_dist = Inf and an NA match. Ties go to the
+# lowest target index.
+#
+# Trigrams rather than Jaro-Winkler because these are multi-word strings of unequal
+# length, which is the case JW handles worst: it dilutes a matching name with a
+# mismatched prefix, so a wrong candidate sharing the prefix can outrank the right one.
+# Measured against TSE ground truth on AC/RR, holding the candidate set fixed, trigrams
+# beat JW on every reference (+0.7 to +6.8 pp within 500 m) and on every p90 error.
 match_strings <- function(query_strings, target_strings) {
   # An inverted word -> target index makes each query's candidate set a lookup, so no
   # query x target matrix is ever built.
@@ -28,6 +35,13 @@ match_strings <- function(query_strings, target_strings) {
   best_index <- rep(NA_integer_, n)
 
   for (i in seq_len(n)) {
+    # A query too short to hold a trigram is incomparable: every candidate scores the
+    # maximum distance, so the winner would be whichever one sorted first. Decline it the
+    # same way as a query no target shares a word with.
+    if (is.na(queries[i]) || nchar(queries[i]) < 3L) {
+      next
+    }
+
     candidates <- sort(unique(unlist(
       word_index[unique(query_words[[i]])],
       use.names = FALSE
@@ -36,7 +50,12 @@ match_strings <- function(query_strings, target_strings) {
       next
     }
 
-    dists <- stringdist::stringdist(queries[i], target_strings[candidates], method = "jw")
+    dists <- stringdist::stringdist(
+      queries[i],
+      target_strings[candidates],
+      method = "jaccard",
+      q = 3
+    )
     best <- which.min(dists)
     min_dist[i] <- dists[best]
     best_index[i] <- candidates[best]
@@ -51,10 +70,17 @@ match_strings <- function(query_strings, target_strings) {
   )
 }
 
-# Unnormalized Jaro-Winkler between paired strings, for the model's per-field similarity
-# features. NA on either side -- no match, or a reference table without that field -- gives NA.
+# Jaccard distance over character trigrams between paired strings, for the model's
+# per-field similarity features. NA on either side -- no match, or a reference table
+# without that field -- gives NA.
+#
+# A string shorter than a trigram has no trigrams, and stringdist scores two such strings
+# as identical whatever they say. Unlike match_strings(), these pairs are not gated on a
+# shared word, so that case can reach here; an incomparable pair is missing, not perfect.
 field_distance <- function(x, y) {
-  stringdist::stringdist(x, y, method = "jw")
+  d <- stringdist::stringdist(x, y, method = "jaccard", q = 3)
+  d[nchar(x) < 3L | nchar(y) < 3L] <- NA_real_
+  d
 }
 
 match_inep_muni <- function(locais_muni, inep_muni) {
@@ -159,8 +185,8 @@ match_stbairro_muni <- function(locais_muni, st_muni, bairro_muni) {
 
   # These two references are coordinate medians over a whole street or neighborhood, so each
   # knows exactly one field; the other three similarities are NA. The one similarity each does
-  # carry repeats its own mindist, since both are now plain Jaro-Winkler on the field the match
-  # was made on. The NA columns are still emitted -- melt_match_candidates() explains why.
+  # carry repeats its own mindist, since both are the same trigram distance on the field the
+  # match was made on. The NA columns are still emitted -- melt_match_candidates() explains why.
   data.table(
     local_id = locais_muni$local_id,
     match_st = st_results$best_match,

--- a/doc/geocoding_procedure.qmd
+++ b/doc/geocoding_procedure.qmd
@@ -82,7 +82,7 @@ The general approach is a follows:
 
 3.  Find the "medioid" (i.e. the median point) for all unique streets and neighborhoods in the CNEFE datasets.
 
-4.  Compute the length-normalized Jaro-Winkler string distance between polling station name and the names of schools in the INEP and  CNEFE data in the same municipality as the polling station.
+4.  Compute the Jaccard string distance over character trigrams between polling station name and the names of schools in the INEP and  CNEFE data in the same municipality as the polling station.
 
 5.  Compute the string distance between the address of polling stations and address of schools in INPE and  CNEFE data.
 
@@ -104,7 +104,7 @@ The *selection* model estimates a candidate's expected error and is what ranks c
 Using the bound to also do the picking --- as earlier versions of this pipeline did --- favors candidates whose error is predictable over candidates whose error is small, and measurably costs accuracy.
 Both models are fit on the following set of covariates:
 
--   Length-normalized Jaro-Winkler string distance of the match that produced the candidate (string-matched sources only).
+-   Trigram string distance of the match that produced the candidate (string-matched sources only).
 -   `geocodebr`'s uncertainty radius, as a separate covariate. It is a distance in kilometers rather than a normalized string distance, so the two do not share a scale and cannot share a column: a six-metre radius would otherwise sort below every possible string distance, and a coarse one above every possible string distance. Each is missing for the candidates the other describes.
 -   Four per-component string distances between the polling station and the matched reference record: school name, street, neighborhood, and whole address line (step 7 above). Each is missing when the source carries no such field.
 -   Coordinate data source
@@ -141,7 +141,7 @@ geocoded_locais <- as.data.table(geocoded_locais)
 ```
 
 To illustrate the string matching procedure, the table below shows the string matching procedure for one polling station where the coordinates are known.
-"String distance" is the length-normalized Jaro-Winkler string distance between the address component and its potential match.
+"String distance" is the Jaccard distance over character trigrams between the address component and its potential match.
 "Expected error" is the error the selection model predicts for that candidate, and "Error bound" is the calibrated 90% upper bound the bound model produces for it.
 The blue row shows the selected match, which is the candidate with the smallest expected error.
 Its error bound is the `conf_dist_km` published for the station, and it is not necessarily the smallest bound in the table --- the two models are ranking on different quantities.

--- a/docs/specs/2026-07-evaluation-spec.md
+++ b/docs/specs/2026-07-evaluation-spec.md
@@ -250,7 +250,7 @@ same reference share a rank — they are the same kind of reference differing on
 so `mindist` decides between them rather than an invented vintage preference.
 
 **Why the tie-break stays inside a rank.** `mindist` is not comparable across ranks — it
-is Jaro-Winkler computed over different fields (name / street / neighborhood / address
+is a trigram distance computed over different fields (name / street / neighborhood / address
 line), and absent for `geocodebr`. A 0.2 name distance and a 0.2 street distance are not
 the same evidence. Within a rank it *is* like-for-like (same matcher, same field), so the
 "smallest `mindist` wins" variant from the assessment is not implemented.

--- a/docs/specs/2026-07-testing-spec.md
+++ b/docs/specs/2026-07-testing-spec.md
@@ -71,7 +71,7 @@ fail loud). Snapshotting current output would lock in the wrong thing.
   - Data.table-in/data.table-out functions (`match_*_muni`, panel functions, `clean_inep`): build the
     smallest input with `data.table(...)` inline — e.g. a 3-row `locais_muni` + 3-row `inep_muni` with
     one obvious name-match, one address-match, one non-match. These functions are deterministic
-    (Jaro-Winkler via `stringdist`), so hand-built cases are stable.
+    (trigram Jaccard via `stringdist`), so hand-built cases are stable.
 - **Single exception — one curated real-string CSV.** For `normalize_address` / `normalize_school`,
   where real-world CNEFE messiness (diacritics, abbreviations, inconsistent spacing) is the point,
   commit **one** small CSV at `tests/testthat/fixtures/` — a couple dozen real, public, hand-picked

--- a/tests/testthat/test-field_distance.R
+++ b/tests/testthat/test-field_distance.R
@@ -1,0 +1,27 @@
+## Spec tests for field_distance() (R/string_matching.R).
+## Jaccard distance over character trigrams between paired strings, feeding the model's
+## per-field sim_* features. Unlike match_strings(), the pairs are not gated on a shared
+## word, so incomparable inputs reach it directly.
+
+test_that("field_distance is 0 for identical strings and 1 for disjoint ones", {
+  expect_equal(field_distance("rua das flores", "rua das flores"), 0)
+  expect_equal(field_distance("abcdefg", "hijklmn"), 1)
+})
+
+test_that("field_distance is NA when either side is missing", {
+  expect_true(is.na(field_distance(NA_character_, "rua das flores")))
+  expect_true(is.na(field_distance("rua das flores", NA_character_)))
+})
+
+test_that("field_distance is NA when a string is too short to have a trigram", {
+  # stringdist scores two sub-trigram strings as identical whatever they say, which would
+  # hand the model a fabricated perfect match between two unrelated fields.
+  expect_true(is.na(field_distance("sn", "ct")))
+  expect_true(is.na(field_distance("sn", "sn")))
+  expect_true(is.na(field_distance("sn", "rua das flores")))
+})
+
+test_that("field_distance is vectorized and preserves order", {
+  out <- field_distance(c("rua das flores", "abcdefg"), c("rua das flores", "hijklmn"))
+  expect_equal(out, c(0, 1))
+})

--- a/tests/testthat/test-match_strings.R
+++ b/tests/testthat/test-match_strings.R
@@ -1,7 +1,7 @@
 ## Spec tests for match_strings() (R/string_matching.R).
-## For each query string it returns the nearest target (Jaro-Winkler), but only among
-## targets that share at least one whitespace-delimited word with the query. A query
-## sharing no word with any target gets no candidate:
+## For each query string it returns the nearest target (Jaccard distance over character
+## trigrams), but only among targets that share at least one whitespace-delimited word
+## with the query. A query sharing no word with any target gets no candidate:
 ## min_dist stays Inf and best_match/best_index are NA. Returns a list of three
 ## parallel vectors: min_dist, best_match, best_index.
 
@@ -37,9 +37,9 @@ test_that("match_strings returns NA/Inf when no target shares a word", {
 })
 
 test_that("match_strings ranks by similarity alone, not string length", {
-  # Jaro-Winkler is already normalized to 0-1, so candidate length must not enter the
-  # ranking. Here the sprawling name is the worse match (JW 0.43 vs 0.30), but dividing
-  # by max(nchar) made its extra 64 characters win the comparison.
+  # The distance is already normalized to 0-1, so candidate length must not enter the
+  # ranking. Here the sprawling name is the worse match, but dividing by max(nchar) made
+  # its extra 64 characters win the comparison.
   res <- match_strings(
     query_strings = "jose joaquim",
     target_strings = c(
@@ -48,7 +48,21 @@ test_that("match_strings ranks by similarity alone, not string length", {
     )
   )
   expect_equal(res$best_index, 2L)
-  expect_equal(res$min_dist, stringdist::stringdist("jose joaquim", "indigena jose joaquim", method = "jw"))
+  expect_equal(
+    res$min_dist,
+    stringdist::stringdist("jose joaquim", "indigena jose joaquim", method = "jaccard", q = 3)
+  )
+})
+
+test_that("match_strings ranks on the whole name, not a shared leading word", {
+  # A real AC/RR case. Jaro-Winkler weights the common prefix and picks the first
+  # candidate, whose coordinate is 105 km from the TSE truth; the second is 34 m away.
+  # Sharing "manoel" is not evidence when the rest of the name disagrees.
+  res <- match_strings(
+    query_strings = "manoel machado",
+    target_strings = c("manoel da cunha neto", "rural manoel machado")
+  )
+  expect_equal(res$best_index, 2L)
 })
 
 test_that("match_strings is case-insensitive when gating candidates", {
@@ -75,4 +89,20 @@ test_that("match_strings handles an empty target set and NA queries", {
 
   res_na <- match_strings(NA_character_, "escola norte")
   expect_true(is.na(res_na$best_index))
+})
+
+test_that("match_strings declines a query too short to hold a trigram", {
+  # "sn" ("sem numero") is a real normalized street value. Every candidate sharing the
+  # token scores the maximum distance, so a match here would be the first candidate by
+  # sort order, not the nearest one.
+  res <- match_strings("sn", c("rua sn a", "avenida sn b", "travessa sn c"))
+  expect_true(is.infinite(res$min_dist))
+  expect_true(is.na(res$best_index))
+  expect_true(is.na(res$best_match))
+})
+
+test_that("match_strings never selects an NA target", {
+  # An NA target carries no word, so it cannot enter a candidate set at all.
+  res <- match_strings("escola norte", c(NA_character_, "escola norte"))
+  expect_equal(res$best_index, 2L)
 })

--- a/tests/testthat/test-normalize_address.R
+++ b/tests/testthat/test-normalize_address.R
@@ -33,6 +33,17 @@ test_that("normalize_address is vectorized and preserves order", {
   expect_equal(out, c("avenida brasil", "rua onze", "sn"))
 })
 
+test_that("normalize_address returns NA when every token was a generic descriptor", {
+  # "ZONA RURAL" is a whole sixth of ds_bairro nationally. Emptied to "", it would
+  # compare equal to every other emptied field under a trigram distance; the field is
+  # missing, not blank.
+  expect_true(is.na(normalize_address("ZONA RURAL")))
+  expect_true(is.na(normalize_address("Povoado")))
+  expect_true(is.na(normalize_address("...")))
+  expect_true(is.na(normalize_address("")))
+  expect_true(is.na(normalize_address(NA_character_)))
+})
+
 test_that("normalize_address matches the curated real-string fixture", {
   fx <- data.table::fread(
     testthat::test_path("fixtures", "normalize_strings.csv"),

--- a/tests/testthat/test-normalize_school.R
+++ b/tests/testthat/test-normalize_school.R
@@ -26,6 +26,13 @@ test_that("normalize_school is vectorized and preserves order", {
   expect_equal(out, c("dom pedro", "tia ana"))
 })
 
+test_that("normalize_school returns NA when the name was nothing but generic terms", {
+  # A station recorded only as its school type has no distinctive name left to match on.
+  expect_true(is.na(normalize_school("Escola Municipal")))
+  expect_true(is.na(normalize_school("CRECHE")))
+  expect_true(is.na(normalize_school(NA_character_)))
+})
+
 test_that("normalize_school matches the curated real-string fixture", {
   fx <- data.table::fread(
     testthat::test_path("fixtures", "normalize_strings.csv"),


### PR DESCRIPTION
## What this is for

The pipeline matches each polling station to the most similar school, street, or
neighborhood record in its municipality. It picked that match by comparing the two
strings character by character (Jaro-Winkler), which is the wrong instrument for names
and addresses: a record sharing a station's *first* word could outrank one matching all
the rest of it. This changes the comparison to count how much of the two strings overlaps
in three-character chunks, so a match is judged on the whole name.

On a full production run this puts **2.6 percentage points more stations within 500 m of
their true location**, with the largest gains in rural areas, and no stratum anywhere
getting worse.

Closes #149.

## The measured result

Production, `no_rescaling_150` (5f5ab96) vs this branch (d3032b9), 258,555 station-years.
Match rate is unchanged in every stratum — this reorders candidates within an unchanged
candidate set, so it cannot drop a station.

| stratum | Δ within 500 m | Δ median km | Δ p90 | Δ p95 |
|---|---|---|---|---|
| **overall** | **+2.63** | −0.003 | −0.84 | −3.53 |
| rural | +5.15 | −0.029 | −4.66 | −7.24 |
| urban | +1.50 | −0.002 | −0.10 | −0.30 |

All ten urban/rural × region cells are positive, from +0.69 (urban:Sudeste) to +6.45
(rural:Norte). There is no negative number in the accuracy table.

**This is not retrain churn.** The trivial precedence selector — model-free, so it cannot
absorb a retrain — moves +3.92 pp overall and is positive in every region and both zones.
It moves *more* than the model does, which is the pattern #150 described: better raw
ranking helps most where nothing is learned on top of it.

**Every source improved its own accuracy**, so the gain is not the model reshuffling
toward a better source: CNEFE 2022 school names 91.7 → 93.8, INEP names 90.7 → 93.2, INEP
addresses 89.1 → 90.8, geocodebr 85.4 → 87.1, and each of the street and neighborhood
aggregates.

Dev mode (AC/RR) predicted this well beforehand — overall +3.35 → +2.63, rural +6.38 →
+5.15, urban +1.85 → +1.50 — overstating the size by about a fifth but getting the
direction and rank order right.

## The issue's premise is wrong; the fix is right anyway

#149 argues that Brazilian station names abbreviate the prefix ("E.M." for "Escola
Municipal") and that Jaro-Winkler cannot rank those variants. That mechanism does not
survive `normalize_school()`, which already strips those terms from a hand-maintained
synonym list — "em", "e m", "ee", "emef", "escola municipal", "ensino fundamental" and
some fifty more. The example pairs in the issue normalize to the same string and match at
distance 0 under any method. In dev, 24 of 10,006 station names retain an unhandled
abbreviation prefix.

The real defect is more basic: Jaro-Winkler is a short-single-token measure, and these are
multi-word strings of unequal length. Consistent with that, the largest gains are in
`inep_addr` and `street` — the fields that get no synonym stripping at all.

This matters because #45 was pursued on a mechanism the data did not support and cost a
production run to reject. The corrected mechanism is recorded here so it is not
re-derived a third time.

## Changes

- `match_strings()` and `field_distance()` use Jaccard distance over character trigrams
  (`stringdist`, `q = 3`). Cosine measured indistinguishably; Jaccard has the better edge
  behavior for ranking.
- **A field normalized down to nothing is now `NA`, not `""`.** Two empty strings share a
  trigram set, so `""` would have scored a perfect match between any two fields whose
  every token was a generic descriptor — "ZONA RURAL" alone is a sixth of recorded
  neighborhoods. This was a live violation of the missing-stays-`NA` rule that the old
  distance happened not to expose.
- `field_distance()` returns `NA`, not 0, for a string too short to hold a trigram;
  `stringdist` scores two such strings as identical whatever they say.
- `match_strings()` declines a query too short to hold a trigram. Such a query ties every
  candidate at the maximum distance, so the "best" match would be whichever candidate
  sorted first.
- `doc/geocoding_procedure.qmd` and the evaluation/testing specs updated in lockstep.
  Three of those lines still said "length-normalized Jaro-Winkler" and had been stale
  since #151 removed the length normalization.

## Review

Unit tests 380 pass. Reviewed at the full tier: an independent Codex pass plus
`/code-review high`. Codex's one finding — that `match_strings()` could emit a fabricated
perfect match for sub-trigram tokens like `"sn"` — does not reproduce as stated, because
the shared-word gate excludes the pair before scoring, but probing it surfaced the
arbitrary-tie problem now fixed above.

## Not done

`doc/geocoding_procedure.Rmd` still sits beside the `.qmd` and is untouched here; that is
#145's subject. The wave tracker (#120) may want an entry, since this landed outside the
roadmap's numbered waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
